### PR TITLE
In glib_object_wrapper!, use generic Class type instead defining a struct

### DIFF
--- a/examples/src/bin/basic_subclass.rs
+++ b/examples/src/bin/basic_subclass.rs
@@ -113,7 +113,7 @@ mod imp_win {
 }
 
 glib_wrapper! {
-    pub struct SimpleWindow(ObjectSubclass<imp_win::SimpleWindow, SimpleWindowClass>)
+    pub struct SimpleWindow(ObjectSubclass<imp_win::SimpleWindow>)
         @extends gtk::Widget, gtk::Container, gtk::Bin, gtk::Window, gtk::ApplicationWindow;
 }
 

--- a/examples/src/bin/listbox_model.rs
+++ b/examples/src/bin/listbox_model.rs
@@ -319,7 +319,7 @@ mod row_data {
     // Public part of the RowData type. This behaves like a normal gtk-rs-style GObject
     // binding
     glib_wrapper! {
-        pub struct RowData(ObjectSubclass<imp::RowData, RowDataClass>);
+        pub struct RowData(ObjectSubclass<imp::RowData>);
     }
 
     // Constructor for new instances. This simply calls glib::Object::new() with

--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -303,11 +303,11 @@ impl<T: ApplicationImpl> ApplicationImplExt for T {
     }
 }
 
-unsafe impl<T: ApplicationImpl> IsSubclassable<T> for ApplicationClass {
-    fn override_vfuncs(&mut self) {
-        <glib::ObjectClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gio_sys::GApplicationClass);
+            let klass = &mut *(class as *mut _ as *mut gio_sys::GApplicationClass);
             klass.activate = Some(application_activate::<T>);
             klass.after_emit = Some(application_after_emit::<T>);
             klass.before_emit = Some(application_before_emit::<T>);

--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -307,7 +307,7 @@ unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gio_sys::GApplicationClass);
+            let klass = &mut *(class.as_mut() as *mut gio_sys::GApplicationClass);
             klass.activate = Some(application_activate::<T>);
             klass.after_emit = Some(application_after_emit::<T>);
             klass.before_emit = Some(application_before_emit::<T>);

--- a/gio/src/subclass/input_stream.rs
+++ b/gio/src/subclass/input_stream.rs
@@ -155,7 +155,7 @@ unsafe impl<T: InputStreamImpl> IsSubclassable<T> for InputStream {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gio_sys::GInputStreamClass);
+            let klass = &mut *(class.as_mut() as *mut gio_sys::GInputStreamClass);
             klass.read_fn = Some(stream_read::<T>);
             klass.close_fn = Some(stream_close::<T>);
             klass.skip = Some(stream_skip::<T>);

--- a/gio/src/subclass/input_stream.rs
+++ b/gio/src/subclass/input_stream.rs
@@ -151,11 +151,11 @@ impl<T: InputStreamImpl> InputStreamImplExt for T {
     }
 }
 
-unsafe impl<T: InputStreamImpl> IsSubclassable<T> for InputStreamClass {
-    fn override_vfuncs(&mut self) {
-        <glib::ObjectClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: InputStreamImpl> IsSubclassable<T> for InputStream {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gio_sys::GInputStreamClass);
+            let klass = &mut *(class as *mut _ as *mut gio_sys::GInputStreamClass);
             klass.read_fn = Some(stream_read::<T>);
             klass.close_fn = Some(stream_close::<T>);
             klass.skip = Some(stream_skip::<T>);

--- a/gio/src/subclass/io_stream.rs
+++ b/gio/src/subclass/io_stream.rs
@@ -99,7 +99,7 @@ unsafe impl<T: IOStreamImpl> IsSubclassable<T> for IOStream {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gio_sys::GIOStreamClass);
+            let klass = &mut *(class.as_mut() as *mut gio_sys::GIOStreamClass);
             klass.get_input_stream = Some(stream_get_input_stream::<T>);
             klass.get_output_stream = Some(stream_get_output_stream::<T>);
             klass.close_fn = Some(stream_close::<T>);

--- a/gio/src/subclass/io_stream.rs
+++ b/gio/src/subclass/io_stream.rs
@@ -95,11 +95,11 @@ impl<T: IOStreamImpl> IOStreamImplExt for T {
     }
 }
 
-unsafe impl<T: IOStreamImpl> IsSubclassable<T> for IOStreamClass {
-    fn override_vfuncs(&mut self) {
-        <glib::ObjectClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: IOStreamImpl> IsSubclassable<T> for IOStream {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gio_sys::GIOStreamClass);
+            let klass = &mut *(class as *mut _ as *mut gio_sys::GIOStreamClass);
             klass.get_input_stream = Some(stream_get_input_stream::<T>);
             klass.get_output_stream = Some(stream_get_output_stream::<T>);
             klass.close_fn = Some(stream_close::<T>);

--- a/gio/src/subclass/output_stream.rs
+++ b/gio/src/subclass/output_stream.rs
@@ -191,11 +191,11 @@ impl<T: OutputStreamImpl> OutputStreamImplExt for T {
     }
 }
 
-unsafe impl<T: OutputStreamImpl> IsSubclassable<T> for OutputStreamClass {
-    fn override_vfuncs(&mut self) {
-        <glib::ObjectClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: OutputStreamImpl> IsSubclassable<T> for OutputStream {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gio_sys::GOutputStreamClass);
+            let klass = &mut *(class as *mut _ as *mut gio_sys::GOutputStreamClass);
             klass.write_fn = Some(stream_write::<T>);
             klass.close_fn = Some(stream_close::<T>);
             klass.flush = Some(stream_flush::<T>);

--- a/gio/src/subclass/output_stream.rs
+++ b/gio/src/subclass/output_stream.rs
@@ -195,7 +195,7 @@ unsafe impl<T: OutputStreamImpl> IsSubclassable<T> for OutputStream {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <glib::Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gio_sys::GOutputStreamClass);
+            let klass = &mut *(class.as_mut() as *mut gio_sys::GOutputStreamClass);
             klass.write_fn = Some(stream_write::<T>);
             klass.close_fn = Some(stream_close::<T>);
             klass.flush = Some(stream_flush::<T>);

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -104,8 +104,8 @@ pub use closure::Closure;
 pub use error::{BoolError, Error};
 pub use file_error::FileError;
 pub use object::{
-    Cast, InitiallyUnowned, InitiallyUnownedClass, IsA, IsClassFor, Object, ObjectClass, ObjectExt,
-    ObjectType, SendWeakRef, WeakRef,
+    Cast, InitiallyUnowned, InitiallyUnownedClass, IsA, Object, ObjectClass, ObjectExt, ObjectType,
+    SendWeakRef, WeakRef,
 };
 pub use signal::{
     signal_handler_block, signal_handler_disconnect, signal_handler_unblock,

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -2518,6 +2518,18 @@ impl<T: ObjectType> Class<T> {
 unsafe impl<T: ObjectType> Send for Class<T> {}
 unsafe impl<T: ObjectType> Sync for Class<T> {}
 
+impl<T: ObjectType> AsRef<T::GlibClassType> for Class<T> {
+    fn as_ref(&self) -> &T::GlibClassType {
+        &self.0
+    }
+}
+
+impl<T: ObjectType> AsMut<T::GlibClassType> for Class<T> {
+    fn as_mut(&mut self) -> &mut T::GlibClassType {
+        &mut self.0
+    }
+}
+
 // This should require Self: IsA<Self::Super>, but that seems to cause a cycle error
 pub unsafe trait ParentClassIs: ObjectType {
     type Parent: ObjectType;

--- a/glib/src/prelude.rs
+++ b/glib/src/prelude.rs
@@ -1,6 +1,6 @@
 //! Traits and essential types intended for blanket imports.
 
 pub use {
-    Cast, Continue, IsA, IsClassFor, ObjectExt, ObjectType, ParamSpecType, StaticType,
-    StaticVariantType, ToSendValue, ToValue, ToVariant,
+    Cast, Continue, IsA, ObjectExt, ObjectType, ParamSpecType, StaticType, StaticVariantType,
+    ToSendValue, ToValue, ToVariant,
 };

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -195,7 +195,7 @@
 //!
 //! // Optionally, define a wrapper type to make it more ergonomic to use from Rust
 //! glib_wrapper! {
-//!     pub struct SimpleObject(ObjectSubclass<imp::SimpleObject, SimpleObjectClass>);
+//!     pub struct SimpleObject(ObjectSubclass<imp::SimpleObject>);
 //! }
 //!
 //! impl SimpleObject {

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -269,10 +269,10 @@ pub unsafe trait ObjectClassSubclassExt: Sized + 'static {
 
 unsafe impl ObjectClassSubclassExt for ObjectClass {}
 
-unsafe impl<T: ObjectImpl> IsSubclassable<T> for ObjectClass {
-    fn override_vfuncs(&mut self) {
+unsafe impl<T: ObjectImpl> IsSubclassable<T> for Object {
+    fn override_vfuncs(class: &mut ::object::Class<Self>) {
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gobject_sys::GObjectClass);
+            let klass = &mut *(class as *mut _ as *mut gobject_sys::GObjectClass);
             klass.set_property = Some(set_property::<T>);
             klass.get_property = Some(get_property::<T>);
             klass.constructed = Some(constructed::<T>);

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -272,7 +272,7 @@ unsafe impl ObjectClassSubclassExt for ObjectClass {}
 unsafe impl<T: ObjectImpl> IsSubclassable<T> for Object {
     fn override_vfuncs(class: &mut ::object::Class<Self>) {
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gobject_sys::GObjectClass);
+            let klass = &mut *(class.as_mut() as *mut gobject_sys::GObjectClass);
             klass.set_property = Some(set_property::<T>);
             klass.get_property = Some(get_property::<T>);
             klass.constructed = Some(constructed::<T>);

--- a/glib/src/subclass/simple.rs
+++ b/glib/src/subclass/simple.rs
@@ -56,7 +56,7 @@ unsafe impl<T: ObjectSubclass> super::types::ClassStruct for ClassStruct<T> {
 }
 
 impl<T: ObjectSubclass> ops::Deref for ClassStruct<T> {
-    type Target = <<T as ObjectSubclass>::ParentType as ObjectType>::RustClassType;
+    type Target = ::object::Class<<T as ObjectSubclass>::ParentType>;
 
     fn deref(&self) -> &Self::Target {
         unsafe { &*(self as *const _ as *const Self::Target) }

--- a/glib/src/wrapper.rs
+++ b/glib/src/wrapper.rs
@@ -329,144 +329,156 @@ macro_rules! glib_wrapper {
     // Object, no class struct, no parents or interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>);
+        pub struct $name:ident(Object<$ffi_name:ty $(, $rust_class_name:ident)?>);
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void, $rust_class_name, @get_type $get_type_expr, @extends [], @implements []);
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void, @get_type $get_type_expr, @extends [], @implements []);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Object, class struct, no parents or interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>);
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty $(, $rust_class_name:ident)?>);
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name, @get_type $get_type_expr, @extends [], @implements []);
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name, @get_type $get_type_expr, @extends [], @implements []);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Object, no class struct, parents, no interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>) @extends $($extends:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty $(, $rust_class_name:ident)?>) @extends $($extends:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void,
             @get_type $get_type_expr, @extends [$($extends),+], @implements []);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Object, class struct, parents, no interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>) @extends $($extends:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty $(, $rust_class_name:ident)?>) @extends $($extends:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name,
             @get_type $get_type_expr, @extends [$($extends),+], @implements []);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Object, no class struct, no parents, interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>) @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty $(, $rust_class_name:ident)?>) @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void,
             @get_type $get_type_expr, @extends [], @implements [$($implements),+]);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Object, class struct, no parents, interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>) @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty $(, $rust_class_name:ident)?>) @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name,
             @get_type $get_type_expr, @extends [], @implements [$($implements),+]);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Object, no class struct, parents and interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty $(, $rust_class_name:ident)?>) @extends $($extends:path),+, @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, ::std::os::raw::c_void,
             @get_type $get_type_expr, @extends [$($extends),+], @implements [$($implements),+]);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Object, class struct, parents and interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
+        pub struct $name:ident(Object<$ffi_name:ty, $ffi_class_name:ty $(, $rust_class_name:ident)?>) @extends $($extends:path),+, @implements $($implements:path),+;
 
         match fn {
             get_type => || $get_type_expr:expr,
         }
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, $ffi_name, $ffi_class_name,
             @get_type $get_type_expr, @extends [$($extends),+], @implements [$($implements),+]);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // ObjectSubclass, no parents or interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>);
+        pub struct $name:ident(ObjectSubclass<$subclass:ty $(, $rust_class_name:ident)?>);
     ) => {
         use glib::translate::ToGlib;
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class,
             @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
             @extends [], @implements []);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // ObjectSubclass, no parents, interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>) @implements $($implements:path),+;
+        pub struct $name:ident(ObjectSubclass<$subclass:ty $(, $rust_class_name:ident)?>) @implements $($implements:path),+;
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class,
             @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
             @extends [], @implements [$($implements),+]);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // ObjectSubclass, parents, no interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>) @extends $($extends:path),+;
+        pub struct $name:ident(ObjectSubclass<$subclass:ty $(, $rust_class_name:ident)?>) @extends $($extends:path),+;
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class,
             @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
             @extends [$($extends),+], @implements []);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // ObjectSubclass, parents and interfaces
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(ObjectSubclass<$subclass:ty, $rust_class_name:ident>) @extends $($extends:path),+, @implements $($implements:path),+;
+        pub struct $name:ident(ObjectSubclass<$subclass:ty $(, $rust_class_name:ident)?>) @extends $($extends:path),+, @implements $($implements:path),+;
     ) => {
-        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class, $rust_class_name,
+        $crate::glib_object_wrapper!(@object [$($attr)*] $name, <$subclass as $crate::subclass::types::ObjectSubclass>::Instance, <$subclass as $crate::subclass::types::ObjectSubclass>::Class,
             @get_type $crate::translate::ToGlib::to_glib(&<$subclass as $crate::subclass::types::ObjectSubclass>::get_type()),
             @extends [$($extends),+], @implements [$($implements),+]);
+        $( pub type $rust_class_name = $crate::object::Class<$name>; )?
     };
 
     // Interface, no prerequisites

--- a/gtk/src/subclass/application.rs
+++ b/gtk/src/subclass/application.rs
@@ -5,7 +5,6 @@ use glib::translate::*;
 use glib::subclass::prelude::*;
 
 use Application;
-use ApplicationClass;
 use Window;
 
 pub trait GtkApplicationImpl:
@@ -49,8 +48,8 @@ impl<T: GtkApplicationImpl> GtkApplicationImplExt for T {
     }
 }
 
-unsafe impl<T: GtkApplicationImpl> IsSubclassable<T> for ApplicationClass {
-    fn override_vfuncs(&mut self) {
+unsafe impl<T: GtkApplicationImpl> IsSubclassable<T> for Application {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         unsafe extern "C" fn application_window_added<T: GtkApplicationImpl>(
             ptr: *mut gtk_sys::GtkApplication,
             wptr: *mut gtk_sys::GtkWindow,
@@ -82,13 +81,13 @@ unsafe impl<T: GtkApplicationImpl> IsSubclassable<T> for ApplicationClass {
             imp.startup(&wrap)
         }
 
-        <gio::ApplicationClass as IsSubclassable<T>>::override_vfuncs(self);
+        <gio::Application as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkApplicationClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkApplicationClass);
             klass.window_added = Some(application_window_added::<T>);
             klass.window_removed = Some(application_window_removed::<T>);
             // Chain our startup handler in here
-            let klass = &mut *(self as *mut Self as *mut gio_sys::GApplicationClass);
+            let klass = &mut *(class as *mut _ as *mut gio_sys::GApplicationClass);
             klass.startup = Some(application_startup::<T>);
         }
     }

--- a/gtk/src/subclass/application.rs
+++ b/gtk/src/subclass/application.rs
@@ -83,11 +83,11 @@ unsafe impl<T: GtkApplicationImpl> IsSubclassable<T> for Application {
 
         <gio::Application as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkApplicationClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkApplicationClass);
             klass.window_added = Some(application_window_added::<T>);
             klass.window_removed = Some(application_window_removed::<T>);
             // Chain our startup handler in here
-            let klass = &mut *(class as *mut _ as *mut gio_sys::GApplicationClass);
+            let klass = &mut class.as_mut().parent_class;
             klass.startup = Some(application_startup::<T>);
         }
     }

--- a/gtk/src/subclass/application_window.rs
+++ b/gtk/src/subclass/application_window.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::window::WindowImpl;
-use ApplicationWindowClass;
-use WindowClass;
+use ApplicationWindow;
+use Window;
 
 pub trait ApplicationWindowImpl: WindowImpl {}
 
-unsafe impl<T: ApplicationWindowImpl> IsSubclassable<T> for ApplicationWindowClass {
-    fn override_vfuncs(&mut self) {
-        <WindowClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: ApplicationWindowImpl> IsSubclassable<T> for ApplicationWindow {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Window as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/bin.rs
+++ b/gtk/src/subclass/bin.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::container::ContainerImpl;
-use BinClass;
-use ContainerClass;
+use Bin;
+use Container;
 
 pub trait BinImpl: ContainerImpl {}
 
-unsafe impl<T: BinImpl> IsSubclassable<T> for BinClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: BinImpl> IsSubclassable<T> for Bin {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/box_.rs
+++ b/gtk/src/subclass/box_.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::container::ContainerImpl;
-use BoxClass;
-use ContainerClass;
+use Box;
+use Container;
 
 pub trait BoxImpl: ContainerImpl {}
 
-unsafe impl<T: BoxImpl> IsSubclassable<T> for BoxClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: BoxImpl> IsSubclassable<T> for Box {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/cell_renderer.rs
+++ b/gtk/src/subclass/cell_renderer.rs
@@ -11,11 +11,10 @@ use glib::object::IsA;
 use glib::subclass::prelude::*;
 use glib::translate::*;
 use glib::GString;
-use glib::ObjectClass;
+use glib::Object;
 
 use CellEditable;
 use CellRenderer;
-use CellRendererClass;
 use CellRendererState;
 use SizeRequestMode;
 use Widget;
@@ -436,11 +435,11 @@ impl<T: CellRendererImpl> CellRendererImplExt for T {
     }
 }
 
-unsafe impl<T: CellRendererImpl> IsSubclassable<T> for CellRendererClass {
-    fn override_vfuncs(&mut self) {
-        <ObjectClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererImpl> IsSubclassable<T> for CellRenderer {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkCellRendererClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererClass);
             klass.get_request_mode = Some(cell_renderer_get_request_mode::<T>);
             klass.get_preferred_width = Some(cell_renderer_get_preferred_width::<T>);
             klass.get_preferred_height_for_width =

--- a/gtk/src/subclass/cell_renderer.rs
+++ b/gtk/src/subclass/cell_renderer.rs
@@ -439,7 +439,7 @@ unsafe impl<T: CellRendererImpl> IsSubclassable<T> for CellRenderer {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkCellRendererClass);
             klass.get_request_mode = Some(cell_renderer_get_request_mode::<T>);
             klass.get_preferred_width = Some(cell_renderer_get_preferred_width::<T>);
             klass.get_preferred_height_for_width =

--- a/gtk/src/subclass/cell_renderer_accel.rs
+++ b/gtk/src/subclass/cell_renderer_accel.rs
@@ -9,8 +9,7 @@ use glib::GString;
 
 use super::cell_renderer_text::CellRendererTextImpl;
 use CellRendererAccel;
-use CellRendererAccelClass;
-use CellRendererTextClass;
+use CellRendererText;
 
 pub trait CellRendererAccelImpl: CellRendererAccelImplExt + CellRendererTextImpl {
     fn accel_edited(
@@ -78,11 +77,11 @@ impl<T: CellRendererAccelImpl> CellRendererAccelImplExt for T {
     }
 }
 
-unsafe impl<T: CellRendererAccelImpl> IsSubclassable<T> for CellRendererAccelClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererTextClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererAccelImpl> IsSubclassable<T> for CellRendererAccel {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRendererText as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkCellRendererAccelClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererAccelClass);
             klass.accel_edited = Some(cell_renderer_accel_edited::<T>);
             klass.accel_cleared = Some(cell_renderer_accel_cleared::<T>);
         }

--- a/gtk/src/subclass/cell_renderer_accel.rs
+++ b/gtk/src/subclass/cell_renderer_accel.rs
@@ -81,7 +81,7 @@ unsafe impl<T: CellRendererAccelImpl> IsSubclassable<T> for CellRendererAccel {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <CellRendererText as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererAccelClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkCellRendererAccelClass);
             klass.accel_edited = Some(cell_renderer_accel_edited::<T>);
             klass.accel_cleared = Some(cell_renderer_accel_cleared::<T>);
         }

--- a/gtk/src/subclass/cell_renderer_combo.rs
+++ b/gtk/src/subclass/cell_renderer_combo.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::cell_renderer_text::CellRendererTextImpl;
-use CellRendererComboClass;
-use CellRendererTextClass;
+use CellRendererCombo;
+use CellRendererText;
 
 pub trait CellRendererComboImpl: CellRendererTextImpl {}
 
-unsafe impl<T: CellRendererComboImpl> IsSubclassable<T> for CellRendererComboClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererTextClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererComboImpl> IsSubclassable<T> for CellRendererCombo {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRendererText as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/cell_renderer_pixbuf.rs
+++ b/gtk/src/subclass/cell_renderer_pixbuf.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::cell_renderer::CellRendererImpl;
-use CellRendererClass;
-use CellRendererPixbufClass;
+use CellRenderer;
+use CellRendererPixbuf;
 
 pub trait CellRendererPixbufImpl: CellRendererImpl {}
 
-unsafe impl<T: CellRendererPixbufImpl> IsSubclassable<T> for CellRendererPixbufClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererPixbufImpl> IsSubclassable<T> for CellRendererPixbuf {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRenderer as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/cell_renderer_progress.rs
+++ b/gtk/src/subclass/cell_renderer_progress.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::cell_renderer::CellRendererImpl;
-use CellRendererClass;
-use CellRendererProgressClass;
+use CellRenderer;
+use CellRendererProgress;
 
 pub trait CellRendererProgressImpl: CellRendererImpl {}
 
-unsafe impl<T: CellRendererProgressImpl> IsSubclassable<T> for CellRendererProgressClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererProgressImpl> IsSubclassable<T> for CellRendererProgress {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRenderer as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/cell_renderer_spin.rs
+++ b/gtk/src/subclass/cell_renderer_spin.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::cell_renderer_text::CellRendererTextImpl;
-use CellRendererSpinClass;
-use CellRendererTextClass;
+use CellRendererSpin;
+use CellRendererText;
 
 pub trait CellRendererSpinImpl: CellRendererTextImpl {}
 
-unsafe impl<T: CellRendererSpinImpl> IsSubclassable<T> for CellRendererSpinClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererTextClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererSpinImpl> IsSubclassable<T> for CellRendererSpin {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRendererText as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/cell_renderer_spinner.rs
+++ b/gtk/src/subclass/cell_renderer_spinner.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::cell_renderer::CellRendererImpl;
-use CellRendererClass;
-use CellRendererSpinnerClass;
+use CellRenderer;
+use CellRendererSpinner;
 
 pub trait CellRendererSpinnerImpl: CellRendererImpl {}
 
-unsafe impl<T: CellRendererSpinnerImpl> IsSubclassable<T> for CellRendererSpinnerClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererSpinnerImpl> IsSubclassable<T> for CellRendererSpinner {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRenderer as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/cell_renderer_text.rs
+++ b/gtk/src/subclass/cell_renderer_text.rs
@@ -7,9 +7,8 @@ use glib::translate::*;
 use glib::GString;
 
 use super::cell_renderer::CellRendererImpl;
-use CellRendererClass;
+use CellRenderer;
 use CellRendererText;
-use CellRendererTextClass;
 
 pub trait CellRendererTextImpl: CellRendererTextImplExt + CellRendererImpl {
     fn edited(&self, renderer: &CellRendererText, path: &str, new_text: &str) {
@@ -38,11 +37,11 @@ impl<T: CellRendererTextImpl> CellRendererTextImplExt for T {
     }
 }
 
-unsafe impl<T: CellRendererTextImpl> IsSubclassable<T> for CellRendererTextClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererTextImpl> IsSubclassable<T> for CellRendererText {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRenderer as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkCellRendererTextClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererTextClass);
             klass.edited = Some(cell_renderer_text_edited::<T>);
         }
     }

--- a/gtk/src/subclass/cell_renderer_text.rs
+++ b/gtk/src/subclass/cell_renderer_text.rs
@@ -41,7 +41,7 @@ unsafe impl<T: CellRendererTextImpl> IsSubclassable<T> for CellRendererText {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <CellRenderer as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererTextClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkCellRendererTextClass);
             klass.edited = Some(cell_renderer_text_edited::<T>);
         }
     }

--- a/gtk/src/subclass/cell_renderer_toggle.rs
+++ b/gtk/src/subclass/cell_renderer_toggle.rs
@@ -7,9 +7,8 @@ use glib::translate::*;
 use glib::GString;
 
 use super::cell_renderer::CellRendererImpl;
-use CellRendererClass;
+use CellRenderer;
 use CellRendererToggle;
-use CellRendererToggleClass;
 
 pub trait CellRendererToggleImpl: CellRendererToggleImplExt + CellRendererImpl {
     fn toggled(&self, renderer: &CellRendererToggle, path: &str) {
@@ -34,11 +33,11 @@ impl<T: CellRendererToggleImpl> CellRendererToggleImplExt for T {
     }
 }
 
-unsafe impl<T: CellRendererToggleImpl> IsSubclassable<T> for CellRendererToggleClass {
-    fn override_vfuncs(&mut self) {
-        <CellRendererClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: CellRendererToggleImpl> IsSubclassable<T> for CellRendererToggle {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <CellRenderer as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkCellRendererToggleClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererToggleClass);
             klass.toggled = Some(cell_renderer_toggle_toggled::<T>);
         }
     }

--- a/gtk/src/subclass/cell_renderer_toggle.rs
+++ b/gtk/src/subclass/cell_renderer_toggle.rs
@@ -37,7 +37,7 @@ unsafe impl<T: CellRendererToggleImpl> IsSubclassable<T> for CellRendererToggle 
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <CellRenderer as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkCellRendererToggleClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkCellRendererToggleClass);
             klass.toggled = Some(cell_renderer_toggle_toggled::<T>);
         }
     }

--- a/gtk/src/subclass/container.rs
+++ b/gtk/src/subclass/container.rs
@@ -6,9 +6,7 @@ use glib::subclass::prelude::*;
 
 use super::widget::WidgetImpl;
 use Container;
-use ContainerClass;
 use Widget;
-use WidgetClass;
 use WidgetPath;
 
 pub trait ContainerImpl: ContainerImplExt + WidgetImpl {
@@ -131,11 +129,11 @@ impl<T: ContainerImpl> ContainerImplExt for T {
     }
 }
 
-unsafe impl<T: ContainerImpl> IsSubclassable<T> for ContainerClass {
-    fn override_vfuncs(&mut self) {
-        <WidgetClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: ContainerImpl> IsSubclassable<T> for Container {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Widget as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkContainerClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkContainerClass);
             klass.add = Some(container_add::<T>);
             klass.remove = Some(container_remove::<T>);
             klass.check_resize = Some(container_check_resize::<T>);

--- a/gtk/src/subclass/container.rs
+++ b/gtk/src/subclass/container.rs
@@ -133,7 +133,7 @@ unsafe impl<T: ContainerImpl> IsSubclassable<T> for Container {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Widget as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkContainerClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkContainerClass);
             klass.add = Some(container_add::<T>);
             klass.remove = Some(container_remove::<T>);
             klass.check_resize = Some(container_check_resize::<T>);

--- a/gtk/src/subclass/dialog.rs
+++ b/gtk/src/subclass/dialog.rs
@@ -6,9 +6,8 @@ use glib::subclass::prelude::*;
 
 use super::window::WindowImpl;
 use Dialog;
-use DialogClass;
 use ResponseType;
-use WindowClass;
+use Window;
 
 pub trait DialogImpl: DialogImplExt + WindowImpl {
     fn response(&self, dialog: &Dialog, response: ResponseType) {
@@ -47,11 +46,11 @@ impl<T: DialogImpl> DialogImplExt for T {
     }
 }
 
-unsafe impl<T: DialogImpl> IsSubclassable<T> for DialogClass {
-    fn override_vfuncs(&mut self) {
-        <WindowClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: DialogImpl> IsSubclassable<T> for Dialog {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Window as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkDialogClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkDialogClass);
             klass.response = Some(dialog_response::<T>);
             klass.close = Some(dialog_close::<T>);
         }

--- a/gtk/src/subclass/dialog.rs
+++ b/gtk/src/subclass/dialog.rs
@@ -50,7 +50,7 @@ unsafe impl<T: DialogImpl> IsSubclassable<T> for Dialog {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Window as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkDialogClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkDialogClass);
             klass.response = Some(dialog_response::<T>);
             klass.close = Some(dialog_close::<T>);
         }

--- a/gtk/src/subclass/drawing_area.rs
+++ b/gtk/src/subclass/drawing_area.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::widget::WidgetImpl;
-use DrawingAreaClass;
-use WidgetClass;
+use DrawingArea;
+use Widget;
 
 pub trait DrawingAreaImpl: WidgetImpl {}
 
-unsafe impl<T: DrawingAreaImpl> IsSubclassable<T> for DrawingAreaClass {
-    fn override_vfuncs(&mut self) {
-        <WidgetClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: DrawingAreaImpl> IsSubclassable<T> for DrawingArea {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Widget as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/event_box.rs
+++ b/gtk/src/subclass/event_box.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::bin::BinImpl;
-use BinClass;
-use EventBoxClass;
+use Bin;
+use EventBox;
 
 pub trait EventBoxImpl: BinImpl {}
 
-unsafe impl<T: EventBoxImpl> IsSubclassable<T> for EventBoxClass {
-    fn override_vfuncs(&mut self) {
-        <BinClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: EventBoxImpl> IsSubclassable<T> for EventBox {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Bin as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/fixed.rs
+++ b/gtk/src/subclass/fixed.rs
@@ -5,13 +5,13 @@
 use glib::subclass::prelude::*;
 
 use super::container::ContainerImpl;
-use ContainerClass;
-use FixedClass;
+use Container;
+use Fixed;
 
 pub trait FixedImpl: ContainerImpl {}
 
-unsafe impl<T: FixedImpl> IsSubclassable<T> for FixedClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: FixedImpl> IsSubclassable<T> for Fixed {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/header_bar.rs
+++ b/gtk/src/subclass/header_bar.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::container::ContainerImpl;
-use ContainerClass;
-use HeaderBarClass;
+use Container;
+use HeaderBar;
 
 pub trait HeaderBarImpl: ContainerImpl {}
 
-unsafe impl<T: HeaderBarImpl> IsSubclassable<T> for HeaderBarClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: HeaderBarImpl> IsSubclassable<T> for HeaderBar {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/icon_view.rs
+++ b/gtk/src/subclass/icon_view.rs
@@ -7,9 +7,8 @@ use glib::subclass::prelude::*;
 use glib::translate::*;
 
 use super::container::ContainerImpl;
-use ContainerClass;
+use Container;
 use IconView;
-use IconViewClass;
 use MovementStep;
 use TreePath;
 
@@ -140,11 +139,11 @@ impl<T: IconViewImpl> IconViewImplExt for T {
     }
 }
 
-unsafe impl<T: IconViewImpl> IsSubclassable<T> for IconViewClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: IconViewImpl> IsSubclassable<T> for IconView {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkIconViewClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkIconViewClass);
             klass.item_activated = Some(icon_view_item_activated::<T>);
             klass.selection_changed = Some(icon_view_selection_changed::<T>);
             klass.select_all = Some(icon_view_select_all::<T>);

--- a/gtk/src/subclass/icon_view.rs
+++ b/gtk/src/subclass/icon_view.rs
@@ -143,7 +143,7 @@ unsafe impl<T: IconViewImpl> IsSubclassable<T> for IconView {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Container as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkIconViewClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkIconViewClass);
             klass.item_activated = Some(icon_view_item_activated::<T>);
             klass.selection_changed = Some(icon_view_selection_changed::<T>);
             klass.select_all = Some(icon_view_select_all::<T>);

--- a/gtk/src/subclass/list_box.rs
+++ b/gtk/src/subclass/list_box.rs
@@ -10,9 +10,8 @@ use super::{container::ContainerImpl, widget::WidgetImpl};
 
 use libc::c_int;
 
-use ContainerClass;
+use Container;
 use ListBox;
-use ListBoxClass;
 use ListBoxRow;
 use MovementStep;
 
@@ -146,11 +145,11 @@ impl<T: ListBoxImpl> ListBoxImplExt for T {
     }
 }
 
-unsafe impl<T: ListBoxImpl> IsSubclassable<T> for ListBoxClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: ListBoxImpl> IsSubclassable<T> for ListBox {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkListBoxClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkListBoxClass);
             klass.activate_cursor_row = Some(list_box_activate_cursor_row::<T>);
             klass.move_cursor = Some(list_box_move_cursor::<T>);
             klass.row_activated = Some(list_box_row_activated::<T>);

--- a/gtk/src/subclass/list_box.rs
+++ b/gtk/src/subclass/list_box.rs
@@ -149,7 +149,7 @@ unsafe impl<T: ListBoxImpl> IsSubclassable<T> for ListBox {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Container as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkListBoxClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkListBoxClass);
             klass.activate_cursor_row = Some(list_box_activate_cursor_row::<T>);
             klass.move_cursor = Some(list_box_move_cursor::<T>);
             klass.row_activated = Some(list_box_row_activated::<T>);

--- a/gtk/src/subclass/list_box_row.rs
+++ b/gtk/src/subclass/list_box_row.rs
@@ -2,9 +2,8 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use BinClass;
+use Bin;
 use ListBoxRow;
-use ListBoxRowClass;
 
 use glib::subclass::prelude::*;
 use glib::translate::*;
@@ -21,11 +20,11 @@ pub trait ListBoxRowImplExt {
     fn list_box_row_activate(&self, list_box_row: &ListBoxRow);
 }
 
-unsafe impl<T: ListBoxRowImpl> IsSubclassable<T> for ListBoxRowClass {
-    fn override_vfuncs(&mut self) {
-        <BinClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: ListBoxRowImpl> IsSubclassable<T> for ListBoxRow {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Bin as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkListBoxRowClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkListBoxRowClass);
             klass.activate = Some(list_box_row_activate::<T>);
         }
     }

--- a/gtk/src/subclass/list_box_row.rs
+++ b/gtk/src/subclass/list_box_row.rs
@@ -24,7 +24,7 @@ unsafe impl<T: ListBoxRowImpl> IsSubclassable<T> for ListBoxRow {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Bin as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkListBoxRowClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkListBoxRowClass);
             klass.activate = Some(list_box_row_activate::<T>);
         }
     }

--- a/gtk/src/subclass/plug.rs
+++ b/gtk/src/subclass/plug.rs
@@ -8,8 +8,7 @@ use glib::translate::*;
 
 use super::window::WindowImpl;
 use Plug;
-use PlugClass;
-use WindowClass;
+use Window;
 
 pub trait PlugImpl: PlugImplExt + WindowImpl {
     fn embedded(&self, plug: &Plug) {
@@ -33,11 +32,11 @@ impl<T: PlugImpl> PlugImplExt for T {
     }
 }
 
-unsafe impl<T: PlugImpl> IsSubclassable<T> for PlugClass {
-    fn override_vfuncs(&mut self) {
-        <WindowClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: PlugImpl> IsSubclassable<T> for Plug {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Window as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkPlugClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkPlugClass);
             klass.embedded = Some(plug_embedded::<T>);
         }
     }

--- a/gtk/src/subclass/plug.rs
+++ b/gtk/src/subclass/plug.rs
@@ -36,7 +36,7 @@ unsafe impl<T: PlugImpl> IsSubclassable<T> for Plug {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Window as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkPlugClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkPlugClass);
             klass.embedded = Some(plug_embedded::<T>);
         }
     }

--- a/gtk/src/subclass/socket.rs
+++ b/gtk/src/subclass/socket.rs
@@ -54,7 +54,7 @@ unsafe impl<T: SocketImpl> IsSubclassable<T> for Socket {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Container as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkSocketClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkSocketClass);
             klass.plug_added = Some(socket_plug_added::<T>);
             klass.plug_removed = Some(socket_plug_removed::<T>);
         }

--- a/gtk/src/subclass/socket.rs
+++ b/gtk/src/subclass/socket.rs
@@ -8,9 +8,8 @@ use glib::translate::*;
 
 use super::container::ContainerImpl;
 use crate::Inhibit;
-use ContainerClass;
+use Container;
 use Socket;
-use SocketClass;
 
 pub trait SocketImpl: SocketImplExt + ContainerImpl {
     fn plug_added(&self, socket: &Socket) {
@@ -51,11 +50,11 @@ impl<T: SocketImpl> SocketImplExt for T {
     }
 }
 
-unsafe impl<T: SocketImpl> IsSubclassable<T> for SocketClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: SocketImpl> IsSubclassable<T> for Socket {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkSocketClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkSocketClass);
             klass.plug_added = Some(socket_plug_added::<T>);
             klass.plug_removed = Some(socket_plug_removed::<T>);
         }

--- a/gtk/src/subclass/stack.rs
+++ b/gtk/src/subclass/stack.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::container::ContainerImpl;
-use ContainerClass;
-use StackClass;
+use Container;
+use Stack;
 
 pub trait StackImpl: ContainerImpl {}
 
-unsafe impl<T: ContainerImpl> IsSubclassable<T> for StackClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: ContainerImpl> IsSubclassable<T> for Stack {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/tree_view.rs
+++ b/gtk/src/subclass/tree_view.rs
@@ -1,13 +1,13 @@
 use glib::subclass::prelude::*;
 
 use super::container::ContainerImpl;
-use ContainerClass;
-use TreeViewClass;
+use Container;
+use TreeView;
 
 pub trait TreeViewImpl: ContainerImpl {}
 
-unsafe impl<T: ContainerImpl> IsSubclassable<T> for TreeViewClass {
-    fn override_vfuncs(&mut self) {
-        <ContainerClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: ContainerImpl> IsSubclassable<T> for TreeView {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Container as IsSubclassable<T>>::override_vfuncs(class);
     }
 }

--- a/gtk/src/subclass/widget.rs
+++ b/gtk/src/subclass/widget.rs
@@ -6,7 +6,7 @@ use std::mem;
 use glib::translate::*;
 
 use glib::subclass::prelude::*;
-use glib::ObjectClass;
+use glib::Object;
 
 use crate::DragResult;
 use crate::Inhibit;
@@ -18,7 +18,6 @@ use cairo_sys;
 use Allocation;
 use SizeRequestMode;
 use Widget;
-use WidgetClass;
 use WidgetExt;
 
 pub trait WidgetImpl: WidgetImplExt + ObjectImpl {
@@ -915,11 +914,11 @@ impl<T: WidgetImpl> WidgetImplExt for T {
     }
 }
 
-unsafe impl<T: WidgetImpl> IsSubclassable<T> for WidgetClass {
-    fn override_vfuncs(&mut self) {
-        <ObjectClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: WidgetImpl> IsSubclassable<T> for Widget {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkWidgetClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkWidgetClass);
             klass.adjust_baseline_allocation = Some(widget_adjust_baseline_allocation::<T>);
             klass.adjust_baseline_request = Some(widget_adjust_baseline_request::<T>);
             klass.adjust_size_allocation = Some(widget_adjust_size_allocation::<T>);

--- a/gtk/src/subclass/widget.rs
+++ b/gtk/src/subclass/widget.rs
@@ -918,7 +918,7 @@ unsafe impl<T: WidgetImpl> IsSubclassable<T> for Widget {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Object as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkWidgetClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkWidgetClass);
             klass.adjust_baseline_allocation = Some(widget_adjust_baseline_allocation::<T>);
             klass.adjust_baseline_request = Some(widget_adjust_baseline_request::<T>);
             klass.adjust_size_allocation = Some(widget_adjust_size_allocation::<T>);

--- a/gtk/src/subclass/window.rs
+++ b/gtk/src/subclass/window.rs
@@ -5,10 +5,9 @@ use glib::translate::*;
 use glib::subclass::prelude::*;
 
 use super::bin::BinImpl;
-use BinClass;
+use Bin;
 use Widget;
 use Window;
-use WindowClass;
 
 pub trait WindowImpl: WindowImplExt + BinImpl {
     fn set_focus(&self, window: &Window, focus: Option<&Widget>) {
@@ -94,11 +93,11 @@ impl<T: WindowImpl> WindowImplExt for T {
     }
 }
 
-unsafe impl<T: WindowImpl> IsSubclassable<T> for WindowClass {
-    fn override_vfuncs(&mut self) {
-        <BinClass as IsSubclassable<T>>::override_vfuncs(self);
+unsafe impl<T: WindowImpl> IsSubclassable<T> for Window {
+    fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
+        <Bin as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(self as *mut Self as *mut gtk_sys::GtkWindowClass);
+            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkWindowClass);
             klass.set_focus = Some(window_set_focus::<T>);
             klass.activate_focus = Some(window_activate_focus::<T>);
             klass.activate_default = Some(window_activate_default::<T>);

--- a/gtk/src/subclass/window.rs
+++ b/gtk/src/subclass/window.rs
@@ -97,7 +97,7 @@ unsafe impl<T: WindowImpl> IsSubclassable<T> for Window {
     fn override_vfuncs(class: &mut ::glib::object::Class<Self>) {
         <Bin as IsSubclassable<T>>::override_vfuncs(class);
         unsafe {
-            let klass = &mut *(class as *mut _ as *mut gtk_sys::GtkWindowClass);
+            let klass = &mut *(class.as_mut() as *mut gtk_sys::GtkWindowClass);
             klass.set_focus = Some(window_set_focus::<T>);
             klass.activate_focus = Some(window_activate_focus::<T>);
             klass.activate_default = Some(window_activate_default::<T>);


### PR DESCRIPTION
Update of https://github.com/gtk-rs/glib/pull/720 with corresponding changes to other crates.

This makes the `$rust_class_name` argument in `glib_wrapper!` optional. If specified, it defines a `type` alias for the class. At least optionally allowing it is required to avoid breaking lots of gir generated code, but perhaps it can be removed after a change to gir.

This removes the `ObjectType::RustClassType` associated type, since it can't be enforced/assumed by the type system that that is an instance of this generic struct.

The `IsClassFor` trait is also removed, superseded by this generic type.

This also changes the `IsSubclassable` trait to be implemented on the object struct rather than the class struct, since there otherwise would be foreign trait on foreign type errors.
