### PR TITLE
glib-macros: Use absolute paths to the StaticType trait

### DIFF
--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -143,7 +143,7 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
             }
         }
 
-        impl StaticType for #name {
+        impl #crate_ident::StaticType for #name {
             fn static_type() -> #crate_ident::Type {
                 #get_type()
             }

--- a/glib-macros/src/gflags_attribute.rs
+++ b/glib-macros/src/gflags_attribute.rs
@@ -157,7 +157,7 @@ pub fn impl_gflags(input: &DeriveInput, gtype_name: &LitStr) -> TokenStream {
             }
         }
 
-        impl StaticType for #name {
+        impl #crate_ident::StaticType for #name {
             fn static_type() -> #crate_ident::Type {
                 #get_type()
             }


### PR DESCRIPTION
Otherwise code using it derive macros needs to have it in scope already,
which is not very user-friendly.

----

CC @gdesmott 