### PR TITLE
CI: add a docs job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+name: docs
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    name: build
+    container:
+      image: ubuntu:20.10
+    steps:
+      - run: apt-get update -y
+      - run: apt-get install -y libgtk-3-dev libglib2.0-dev libgraphene-1.0-dev git curl libcairo-gobject2 libcairo2-dev
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - working-directory: gir
+        run: cargo build --release
+      - run: ./gir/target/release/gir -c ./atk/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./gdk/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./gdk-pixbuf/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./gdkx11/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./gio/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./graphene/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./gtk/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./pango/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: ./gir/target/release/gir -c ./pangocairo/Gir.toml -d ./gir-files --doc-target-path docs.md -m doc
+      - run: cargo install rustdoc-stripper
+      - run: rustdoc-stripper -g -o ./atk/docs.md
+      - run: rustdoc-stripper -g -o ./gdk/docs.md
+      - run: rustdoc-stripper -g -o ./gdk-pixbuf/docs.md
+      - run: rustdoc-stripper -g -o ./gdkx11/docs.md
+      - run: rustdoc-stripper -g -o ./gio/docs.md
+      - run: rustdoc-stripper -g -o ./graphene/docs.md
+      - run: rustdoc-stripper -g -o ./gtk/docs.md
+      - run: rustdoc-stripper -g -o ./pango/docs.md
+      - run: rustdoc-stripper -g -o ./pangocairo/docs.md
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --workspace --all-features --no-deps
+
+      - name: deploy
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: peaceiris/actions-gh-pages@v2
+        env:
+          PERSONAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH_BRANCH: gh-pages
+          PUBLISH_DIR: ./target/doc/


### PR DESCRIPTION
Build nightly docs & publish them through github pages. The job only runs when something is merged in master. The same thing could be used in the future to build & publish stable docs if needed.