### PR TITLE
glib: Require all the Value traits to be implemented for ObjectType

### DIFF
--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -46,6 +46,10 @@ pub unsafe trait ObjectType:
     + PartialOrd
     + Ord
     + hash::Hash
+    + ::value::SetValue
+    + ::value::SetValueOptional
+    + for<'a> ::value::FromValueOptional<'a>
+    + ::value::ToValue
     + for<'a> ToGlibPtr<'a, *mut <Self as ObjectType>::GlibType>
     + 'static
 {


### PR DESCRIPTION
glib_wrapper! automatically does this and having it included here makes
usage of the IsA trait simpler.