### PR TITLE
generator: Convert to pathlib, fix wrong path passed to various executables

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -296,9 +296,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: python3 generator.py --yes
+        with:
+          submodules: recursive
+      - run: python3 generator.py
       - run: git diff -R --exit-code
- 
+
   checker:
     name: gtk-rs checker
     runs-on: ubuntu-latest

--- a/generator.py
+++ b/generator.py
@@ -147,9 +147,6 @@ def main():
     if conf.gir_files_path == DEFAULT_GIR_FILES_DIRECTORY:
         if def_check_submodule(conf.gir_files_path, conf) == FAILURE:
             return 1
-    elif not isdir(conf.gir_files_path):
-        print("`{}` dir doesn't exist. Aborting...".format(conf.gir_files_path))
-        return 1
 
     if conf.gir_path == DEFAULT_GIR_PATH:
         if not build_gir_if_needed(def_check_submodule(DEFAULT_GIR_DIRECTORY, conf)):

--- a/generator.py
+++ b/generator.py
@@ -72,12 +72,12 @@ def build_gir_if_needed(updated_submodule):
     return True
 
 
-def regen_crates(path, conf, level=0):
+def regen_crates(path, conf):
     if path.is_dir():
-        for entry in path.iterdir():
-            if level < 3 and not regen_crates(entry, conf, level + 1):
+        for entry in path.rglob("Gir*.toml"):
+            if not regen_crates(entry, conf):
                 return False
-    elif path.name.startswith("Gir") and path.suffix == ".toml":
+    elif path.match("Gir*.toml"):
         print('==> Regenerating "{}"...'.format(path))
 
         args = [conf.gir_path, '-c', path, '-o', path.parent, '-d', conf.gir_files_path]
@@ -93,6 +93,9 @@ def regen_crates(path, conf, level=0):
             if not ask_yes_no_question('Do you want to continue?', conf):
                 return False
         print('<== Done!')
+    else:
+        print('==> {} is not a valid Gir*.toml file'.format(path))
+        return False
     return True
 
 

--- a/generator.py
+++ b/generator.py
@@ -11,8 +11,9 @@ NOTHING_TO_BE_DONE = 0
 NEED_UPDATE = 1
 FAILURE = 2
 
-DEFAULT_GIR_DIRECTORY = 'gir-files'
-DEFAULT_GIR_PATH = './gir/target/release/gir'
+DEFAULT_GIR_FILES_DIRECTORY = './gir-files'
+DEFAULT_GIR_DIRECTORY = './gir/'
+DEFAULT_GIR_PATH = DEFAULT_GIR_DIRECTORY + 'target/release/gir'
 
 
 def run_command(command, folder=None):
@@ -85,7 +86,7 @@ def regen_crates(path, conf, level=0):
         elif entry.startswith("Gir") and entry.endswith(".toml"):
             print('==> Regenerating "{}"...'.format(entry_file))
 
-            args = [conf.gir_path, '-c', entry_file, '-o', path, '-d', conf.gir_directory]
+            args = [conf.gir_path, '-c', entry_file, '-o', path, '-d', conf.gir_files_path]
             if level > 1:
                 args.append('-m')
                 args.append('sys')
@@ -102,13 +103,13 @@ def regen_crates(path, conf, level=0):
     return True
 
 
-def parse_args(args):
+def parse_args():
     parser = argparse.ArgumentParser(description='Helper to regenerate gtk-rs crates using gir.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('path', nargs="*", default='.',
                         help='Paths in which to look for Gir.toml files')
-    parser.add_argument('--gir-directory', default=DEFAULT_GIR_DIRECTORY,
+    parser.add_argument('--gir-files', dest="gir_files_path", default=DEFAULT_GIR_FILES_DIRECTORY,
                         help='Path of the gir-files folder')
     parser.add_argument('--gir-path', default=DEFAULT_GIR_PATH,
                         help='Path of the gir executable to run')
@@ -121,19 +122,17 @@ def parse_args(args):
 
 
 def main():
-    gir_path = None
+    conf = parse_args()
 
-    conf = parse_args(sys.argv[1:])
-
-    if conf.gir_directory == DEFAULT_GIR_DIRECTORY:
-        if def_check_submodule("gir-files", conf) == FAILURE:
+    if conf.gir_files_path == DEFAULT_GIR_FILES_DIRECTORY:
+        if def_check_submodule(conf.gir_files_path, conf) == FAILURE:
             return 1
-    elif not isdir(conf.gir_directory):
-        print("`{}` dir doesn't exist. Aborting...".format(conf.gir_directory))
+    elif not isdir(conf.gir_files_path):
+        print("`{}` dir doesn't exist. Aborting...".format(conf.gir_files_path))
         return 1
 
     if conf.gir_path == DEFAULT_GIR_PATH:
-        if not build_gir_if_needed(def_check_submodule("gir", conf)):
+        if not build_gir_if_needed(def_check_submodule(DEFAULT_GIR_DIRECTORY, conf)):
             return 1
     elif not isfile(conf.gir_path):
         print("`{}` file doesn't exist. Aborting...".format(conf.gir_path))

--- a/generator.py
+++ b/generator.py
@@ -129,14 +129,14 @@ def main():
         if def_check_submodule("gir-files", conf) == FAILURE:
             return 1
     elif not isdir(conf.gir_directory):
-        print("`{}` dir doesn't exist. Aborting...".format(path))
+        print("`{}` dir doesn't exist. Aborting...".format(conf.gir_directory))
         return 1
 
     if conf.gir_path == DEFAULT_GIR_PATH:
         if not build_gir_if_needed(def_check_submodule("gir", conf)):
             return 1
     elif not isfile(conf.gir_path):
-        print("`{}` file doesn't exist. Aborting...".format(path))
+        print("`{}` file doesn't exist. Aborting...".format(conf.gir_path))
         return 1
 
     print('=> Regenerating crates...')

--- a/generator.py
+++ b/generator.py
@@ -85,7 +85,7 @@ def regen_crates(path, conf, level=0):
             print('==> Regenerating "{}"...'.format(entry))
 
             args = [conf.gir_path, '-c', entry, '-o', entry.parent, '-d', conf.gir_files_path]
-            if level > 1:
+            if entry.parent.name.endswith("sys"):
                 args.extend(['-m', 'sys'])
             error = False
             try:

--- a/generator.py
+++ b/generator.py
@@ -48,16 +48,16 @@ def ask_yes_no_question(question, conf):
 def def_check_submodule(submodule_path, conf):
     if len(listdir(submodule_path)) != 0:
         return NOTHING_TO_BE_DONE
-    print('=> Initializing gir submodule...')
-    if not run_command(['git', 'submodule', 'update', '--init']):
+    print('=> Initializing {} submodule...'.format(submodule_path))
+    if not run_command(['git', 'submodule', 'update', '--init', submodule_path]):
         return FAILURE
     print('<= Done!')
 
-    if ask_yes_no_question('Do you want to update gir submodule?', conf):
-        print('=> Updating gir submodule...')
-        if not run_command(['git', 'reset', '--hard', 'HEAD'], 'gir'):
+    if ask_yes_no_question('Do you want to update {} submodule?'.format(submodule_path), conf):
+        print('=> Updating submodule...')
+        if not run_command(['git', 'reset', '--hard', 'HEAD'], submodule_path):
             return FAILURE
-        if not run_command(['git', 'pull', '-f', 'origin', 'master'], 'gir'):
+        if not run_command(['git', 'pull', '-f', 'origin', 'master'], submodule_path):
             return FAILURE
         print('<= Done!')
         return NEED_UPDATE

--- a/generator.py
+++ b/generator.py
@@ -18,19 +18,15 @@ DEFAULT_GIR_PATH = DEFAULT_GIR_DIRECTORY / 'target/release/gir'
 def run_command(command, folder=None):
     if folder is None:
         folder = "."
-    child = subprocess.Popen(command, cwd=folder)
-    child.communicate()
-    if child.returncode != 0:
-        print("Command `{}` failed with return code `{}`...".format(command, child.returncode))
+    ret = subprocess.run(command, cwd=folder)
+    if ret.returncode != 0:
+        print("Command `{}` failed with `{}`...".format(command, ret))
         return False
     return True
 
 
 def update_workspace():
-    try:
-        return run_command(['cargo', 'build', '--release'], 'gir')
-    except:
-        return False
+    return run_command(['cargo', 'build', '--release'], 'gir')
 
 
 def ask_yes_no_question(question, conf):

--- a/generator.py
+++ b/generator.py
@@ -100,18 +100,32 @@ def regen_crates(path, conf, level=0):
     return True
 
 
+def directory_path(path):
+    path = Path(path)
+    if not path.is_dir():
+        raise argparse.ArgumentTypeError("`{}` directory not found".format(path))
+    return path
+
+
+def file_path(path):
+    path = Path(path)
+    if not path.is_file():
+        raise argparse.ArgumentTypeError("`{}` file not found".format(path))
+    return path
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description='Helper to regenerate gtk-rs crates using gir.',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('path', nargs="*", default=[Path('.')],
-                        type=Path,
+                        type=directory_path,
                         help='Paths in which to look for Gir.toml files')
     parser.add_argument('--gir-files', dest="gir_files_path", default=DEFAULT_GIR_FILES_DIRECTORY,
-                        type=Path,
+                        type=directory_path,
                         help='Path of the gir-files folder')
     parser.add_argument('--gir-path', default=DEFAULT_GIR_PATH,
-                        type=Path,
+                        type=file_path,
                         help='Path of the gir executable to run')
     parser.add_argument('--yes', action='store_true',
                         help=' Always answer `yes` to any question asked by the script')
@@ -127,16 +141,10 @@ def main():
     if conf.gir_files_path == DEFAULT_GIR_FILES_DIRECTORY:
         if def_check_submodule(conf.gir_files_path, conf) == FAILURE:
             return 1
-    elif not conf.gir_files_path.is_dir():
-        print("`{}` dir doesn't exist. Aborting...".format(conf.gir_files_path))
-        return 1
 
     if conf.gir_path == DEFAULT_GIR_PATH:
         if not build_gir_if_needed(def_check_submodule(DEFAULT_GIR_DIRECTORY, conf)):
             return 1
-    elif not conf.gir_path.is_file():
-        print("`{}` file doesn't exist. Aborting...".format(conf.gir_path))
-        return 1
 
     print('=> Regenerating crates...')
     for path in conf.path:


### PR DESCRIPTION
`def_check_submodule` was always passing `'gir'` even when called with `gir-files`, and the `depth` used to derive whether `Gir.toml` resides in a `sys` crate is inaccurate when specifying eg. `**/sys` on the command line (as that'd be level 0).

In addition, convert path handling to `pathlib` whose paths are constructed and checked during argument parsing.

Please double-check if I overlooked a path anywhere that's still a string instead of `Path`.

EDIT: With pathlib we might also replace the depth-first search in `regen_crates` with `path.glob` or `path.rglob` on `**/Gir*.toml`?

