### PR TITLE
Subclassing for GtkButton, backported from gtk4-rs

### DIFF
--- a/gtk/src/subclass/button.rs
+++ b/gtk/src/subclass/button.rs
@@ -1,0 +1,69 @@
+use glib::subclass::prelude::*;
+use glib::translate::*;
+use glib::Cast;
+
+use super::widget::WidgetImpl;
+use crate::{Button, Widget};
+
+pub trait ButtonImpl: ButtonImplExt + WidgetImpl {
+    fn activate(&self, button: &Self::Type) {
+        self.parent_activate(button)
+    }
+
+    fn clicked(&self, button: &Self::Type) {
+        self.parent_clicked(button)
+    }
+}
+
+pub trait ButtonImplExt: ObjectSubclass {
+    fn parent_activate(&self, button: &Self::Type);
+    fn parent_clicked(&self, button: &Self::Type);
+}
+
+impl<T: ButtonImpl> ButtonImplExt for T {
+    fn parent_activate(&self, button: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut ffi::GtkButtonClass;
+            if let Some(f) = (*parent_class).activate {
+                f(button.unsafe_cast_ref::<Button>().to_glib_none().0)
+            }
+        }
+    }
+
+    fn parent_clicked(&self, button: &Self::Type) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class = data.as_ref().get_parent_class() as *mut ffi::GtkButtonClass;
+            if let Some(f) = (*parent_class).clicked {
+                f(button.unsafe_cast_ref::<Button>().to_glib_none().0)
+            }
+        }
+    }
+}
+
+unsafe impl<T: ButtonImpl> IsSubclassable<T> for Button {
+    fn override_vfuncs(class: &mut glib::Class<Self>) {
+        <Widget as IsSubclassable<T>>::override_vfuncs(class);
+
+        let klass = class.as_mut();
+        klass.activate = Some(button_activate::<T>);
+        klass.clicked = Some(button_clicked::<T>);
+    }
+}
+
+unsafe extern "C" fn button_activate<T: ButtonImpl>(ptr: *mut ffi::GtkButton) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Button> = from_glib_borrow(ptr);
+
+    imp.activate(wrap.unsafe_cast_ref())
+}
+
+unsafe extern "C" fn button_clicked<T: ButtonImpl>(ptr: *mut ffi::GtkButton) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.get_impl();
+    let wrap: Borrowed<Button> = from_glib_borrow(ptr);
+
+    imp.clicked(wrap.unsafe_cast_ref())
+}

--- a/gtk/src/subclass/mod.rs
+++ b/gtk/src/subclass/mod.rs
@@ -6,6 +6,7 @@ pub mod application;
 pub mod application_window;
 pub mod bin;
 pub mod box_;
+pub mod button;
 pub mod cell_renderer;
 pub mod cell_renderer_accel;
 pub mod cell_renderer_combo;
@@ -38,6 +39,7 @@ pub mod prelude {
     pub use super::application_window::ApplicationWindowImpl;
     pub use super::bin::BinImpl;
     pub use super::box_::BoxImpl;
+    pub use super::button::ButtonImpl;
     pub use super::cell_renderer::{CellRendererImpl, CellRendererImplExt};
     pub use super::cell_renderer_accel::{CellRendererAccelImpl, CellRendererAccelImplExt};
     pub use super::cell_renderer_combo::CellRendererComboImpl;


### PR DESCRIPTION
Was added to gtk4-rs in https://github.com/gtk-rs/gtk4-rs/pull/57

This doesn't include the deprecated virtual methods in gtk3 that are not in gtk4. Those could be added, but new projects probably shouldn't be using them anyway.