### PR TITLE
Backport composite templates from gtk4-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "graphene/sys",
   "gtk",
   "gtk/sys",
+  "gtk3-macros",
   "examples",
   "pango",
   "pango/sys",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -97,6 +97,9 @@ name = "clone_macro"
 name = "communication_thread"
 
 [[bin]]
+name = "composite_template"
+
+[[bin]]
 name = "css"
 
 [[bin]]

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -1,0 +1,109 @@
+//! # Composite Template Example
+//!
+//! This sample demonstrates how to create a widget using GTK's composite templates.
+
+use gio::prelude::*;
+use glib::subclass::prelude::*;
+use glib::{glib_object_subclass, glib_wrapper};
+use gtk::{prelude::*, CompositeTemplate};
+
+mod imp {
+    use super::*;
+    use glib::subclass;
+    use gtk::subclass::prelude::*;
+
+    /// The private struct, which can hold widgets and other data.
+    #[derive(Debug, CompositeTemplate)]
+    pub struct ExApplicationWindow {
+        // The #[template_child] attribute tells the CompositeTemplate macro
+        // that a field is meant to be a child within the template.
+        #[template_child(id = "headerbar")]
+        pub headerbar: TemplateChild<gtk::HeaderBar>,
+        #[template_child(id = "label")]
+        pub label: TemplateChild<gtk::Label>,
+        #[template_child(id = "subtitle_label")]
+        pub subtitle: TemplateChild<gtk::Label>,
+    }
+
+    impl ObjectSubclass for ExApplicationWindow {
+        const NAME: &'static str = "ExApplicationWindow";
+        type Type = super::ExApplicationWindow;
+        type ParentType = gtk::ApplicationWindow;
+        type Instance = subclass::simple::InstanceStruct<Self>;
+        type Class = subclass::simple::ClassStruct<Self>;
+
+        glib_object_subclass!();
+
+        fn new() -> Self {
+            Self {
+                headerbar: TemplateChild::default(),
+                label: TemplateChild::default(),
+                subtitle: TemplateChild::default(),
+            }
+        }
+
+        // Within class_init() you must set the template
+        // and bind it's children. The CompositeTemplate
+        // derive macro provides a convenience function
+        // bind_template_children() to bind all children
+        // at once.
+        fn class_init(klass: &mut Self::Class) {
+            let template = include_bytes!("composite_template.ui");
+            klass.set_template(template);
+            Self::bind_template_children(klass);
+        }
+    }
+
+    impl ObjectImpl for ExApplicationWindow {
+        fn constructed(&self, obj: &Self::Type) {
+            obj.init_template();
+            obj.init_label();
+            self.parent_constructed(obj);
+        }
+    }
+
+    impl WidgetImpl for ExApplicationWindow {}
+    impl ContainerImpl for ExApplicationWindow {}
+    impl BinImpl for ExApplicationWindow {}
+    impl WindowImpl for ExApplicationWindow {}
+    impl ApplicationWindowImpl for ExApplicationWindow {}
+}
+
+glib_wrapper! {
+    pub struct ExApplicationWindow(ObjectSubclass<imp::ExApplicationWindow>)
+        @extends gtk::Widget, gtk::Window, gtk::ApplicationWindow, @implements gio::ActionMap, gio::ActionGroup;
+}
+
+impl ExApplicationWindow {
+    pub fn new<P: glib::IsA<gtk::Application>>(app: &P) -> Self {
+        glib::Object::new(Self::static_type(), &[("application", app)])
+            .expect("Failed to create ExApplicationWindow")
+            .downcast::<ExApplicationWindow>()
+            .expect("Created object is of wrong type")
+    }
+
+    pub fn init_label(&self) {
+        // To access fields such as template children, you must get
+        // the private struct.
+        let self_ = imp::ExApplicationWindow::from_instance(self);
+        self_
+            .subtitle
+            .get()
+            .set_text("This is an example window made using composite templates");
+    }
+}
+
+fn main() {
+    let application = gtk::Application::new(
+        Some("com.github.gtk-rs.examples.composite_template"),
+        Default::default(),
+    )
+    .expect("Failed to initialize application");
+
+    application.connect_activate(|app| {
+        let win = ExApplicationWindow::new(app);
+        win.show();
+    });
+
+    application.run(&std::env::args().collect::<Vec<_>>());
+}

--- a/examples/src/bin/composite_template.ui
+++ b/examples/src/bin/composite_template.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="ExApplicationWindow" parent="GtkApplicationWindow">
+    <property name="default_width">600</property>
+    <property name="default_height">300</property>
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="title">Example Application Window</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="headerbar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="show_close_button">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="valign">center</property>
+        <property name="spacing">6</property>
+        <property name="margin_start">12</property>
+        <property name="margin_end">12</property>
+        <property name="margin_top">12</property>
+        <property name="margin_bottom">12</property>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="visible">True</property>
+            <property name="label">Composite Template</property>
+            <style>
+              <class name="large-title"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkLabel" id="subtitle_label">
+            <property name="visible">True</property>
+            <property name="wrap">True</property>
+            <property name="justify">center</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -53,9 +53,11 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
+field-offset = "0.3"
 once_cell = "1.0"
 atk = { path = "../atk" }
 ffi = { package = "gtk-sys", path = "sys" }
+gtk3-macros =  { path = "../gtk3-macros" }
 cairo-rs = { path = "../cairo" }
 gio = { path = "../gio" }
 glib = { path = "../glib" }

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -155,6 +155,11 @@
 
 pub use ffi;
 
+#[doc(hidden)]
+pub use field_offset::*;
+#[doc(hidden)]
+pub use gtk3_macros::*;
+
 pub mod xlib;
 
 pub const STYLE_PROVIDER_PRIORITY_FALLBACK: u32 = ffi::GTK_STYLE_PROVIDER_PRIORITY_FALLBACK as u32;

--- a/gtk/src/subclass/mod.rs
+++ b/gtk/src/subclass/mod.rs
@@ -64,7 +64,9 @@ pub mod prelude {
     pub use super::socket::{SocketImpl, SocketImplExt};
     pub use super::stack::StackImpl;
     pub use super::tree_view::TreeViewImpl;
-    pub use super::widget::{WidgetImpl, WidgetImplExt};
+    pub use super::widget::{
+        CompositeTemplate, TemplateChild, WidgetClassSubclassExt, WidgetImpl, WidgetImplExt,
+    };
     pub use super::window::{WindowImpl, WindowImplExt};
     pub use gio::subclass::prelude::*;
     pub use glib::subclass::prelude::*;

--- a/gtk/src/subclass/widget.rs
+++ b/gtk/src/subclass/widget.rs
@@ -3,6 +3,7 @@ use std::mem;
 
 use glib::translate::*;
 
+use glib::prelude::*;
 use glib::subclass::prelude::*;
 use glib::{Cast, Object};
 
@@ -1560,4 +1561,116 @@ unsafe extern "C" fn widget_scroll_event<T: WidgetImpl>(
     let event: Borrowed<gdk::EventScroll> = from_glib_borrow(mptr);
 
     imp.scroll_event(wrap.unsafe_cast_ref(), &event).to_glib()
+}
+
+pub unsafe trait WidgetClassSubclassExt: ClassStruct {
+    fn set_template_bytes(&mut self, template: &glib::Bytes) {
+        unsafe {
+            let type_class = self as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+            let widget_class =
+                glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                    as *mut ffi::GtkWidgetClass;
+            ffi::gtk_widget_class_set_template(widget_class, template.to_glib_none().0);
+        }
+    }
+
+    fn set_template(&mut self, template: &[u8]) {
+        let template_bytes = glib::Bytes::from(template);
+        self.set_template_bytes(&template_bytes);
+    }
+
+    fn set_template_static(&mut self, template: &'static [u8]) {
+        let template_bytes = glib::Bytes::from_static(template);
+        self.set_template_bytes(&template_bytes);
+    }
+
+    fn set_template_from_resource(&mut self, resource_name: &str) {
+        unsafe {
+            let type_class = self as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+            let widget_class =
+                glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                    as *mut ffi::GtkWidgetClass;
+            ffi::gtk_widget_class_set_template_from_resource(
+                widget_class,
+                resource_name.to_glib_none().0,
+            );
+        }
+    }
+
+    fn bind_template_child(&mut self, name: &str) {
+        unsafe {
+            let type_class = self as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+            let widget_class =
+                glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                    as *mut ffi::GtkWidgetClass;
+            ffi::gtk_widget_class_bind_template_child_full(
+                widget_class,
+                name.to_glib_none().0,
+                false as glib::ffi::gboolean,
+                0,
+            );
+        }
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    unsafe fn bind_template_child_with_offset<T>(
+        &mut self,
+        name: &str,
+        offset: field_offset::FieldOffset<Self::Type, TemplateChild<T>>,
+    ) where
+        T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+    {
+        let type_class = self as *mut _ as *mut glib::gobject_ffi::GTypeClass;
+        let widget_class =
+            glib::gobject_ffi::g_type_check_class_cast(type_class, ffi::gtk_widget_get_type())
+                as *mut ffi::GtkWidgetClass;
+        let private_offset = <Self::Type as ObjectSubclass>::type_data()
+            .as_ref()
+            .private_offset;
+        ffi::gtk_widget_class_bind_template_child_full(
+            widget_class,
+            name.to_glib_none().0,
+            false as glib::ffi::gboolean,
+            private_offset + (offset.get_byte_offset() as isize),
+        )
+    }
+}
+
+unsafe impl<T: ClassStruct> WidgetClassSubclassExt for T where T::Type: WidgetImpl {}
+
+#[derive(Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct TemplateChild<T>
+where
+    T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+{
+    ptr: *mut <T as ObjectType>::GlibType,
+}
+
+impl<T> Default for TemplateChild<T>
+where
+    T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+{
+    fn default() -> Self {
+        Self {
+            ptr: std::ptr::null_mut(),
+        }
+    }
+}
+
+impl<T> TemplateChild<T>
+where
+    T: ObjectType + FromGlibPtrNone<*mut <T as ObjectType>::GlibType>,
+{
+    #[track_caller]
+    pub fn get(&self) -> T {
+        unsafe {
+            Option::<T>::from_glib_none(self.ptr)
+                .expect("Failed to retrieve template child. Please check that it has been bound.")
+        }
+    }
+}
+
+pub trait CompositeTemplate: WidgetImpl {
+    fn bind_template_children(klass: &mut Self::Class);
 }

--- a/gtk3-macros/Cargo.toml
+++ b/gtk3-macros/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+documentation = "https://gtk-rs.org/docs/gtk3-macros/"
+categories = ["api-bindings", "gui"]
+license = "MIT"
+description = "Rust bindings for the GTK 3 library"
+homepage = "https://gtk-rs.org/"
+name = "gtk3-macros"
+version = "0.1.0"
+authors = ["The Gtk-rs Project Developers"]
+edition = "2018"
+keywords = ["gtk", "gtk3", "gtk-rs", "gnome", "GUI"]
+repository = "https://github.com/gtk-rs/gtk-rs"
+exclude = [
+    "gir-files/*",
+]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+anyhow = "1.0"
+heck = "0.3"
+itertools = "0.9"
+proc-macro-error = "1.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"
+proc-macro-crate = "0.1"

--- a/gtk3-macros/src/composite_template_derive.rs
+++ b/gtk3-macros/src/composite_template_derive.rs
@@ -1,0 +1,66 @@
+use proc_macro2::TokenStream;
+use proc_macro_error::abort_call_site;
+use quote::quote;
+use syn::Data;
+
+use std::string::ToString;
+
+use crate::util::*;
+
+fn gen_template_child_bindings(fields: &syn::Fields) -> TokenStream {
+    let crate_ident = crate_ident_new();
+
+    let recurse = fields.iter().map(|f| {
+        let filtered_attrs = f
+            .attrs
+            .clone()
+            .into_iter()
+            .filter(|a| a.path.is_ident("template_child"))
+            .collect::<Vec<syn::Attribute>>();
+        if !filtered_attrs.is_empty() {
+            let ident = f.ident.as_ref().unwrap();
+            let mut value_id = String::new();
+
+            if let Ok(attrs) = parse_template_child_attributes("template_child", &filtered_attrs) {
+                attrs.into_iter().for_each(|a| match a {
+                    TemplateChildAttribute::Id(id) => value_id = id,
+                });
+            }
+
+            quote! {
+                klass.bind_template_child_with_offset(
+                    &#value_id,
+                    #crate_ident::offset_of!(Self => #ident),
+                );
+            }
+        } else {
+            quote! {}
+        }
+    });
+
+    quote! {
+        #(#recurse)*
+    }
+}
+
+pub fn impl_composite_template(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let crate_ident = crate_ident_new();
+
+    let fields = match input.data {
+        Data::Struct(ref s) => &s.fields,
+        _ => abort_call_site!("derive(CompositeTemplate) only supports structs"),
+    };
+
+    let template_children = gen_template_child_bindings(&fields);
+
+    quote! {
+        impl #crate_ident::subclass::widget::CompositeTemplate for #name {
+            fn bind_template_children(klass: &mut Self::Class) {
+                unsafe {
+                    #template_children
+                }
+            }
+        }
+    }
+}

--- a/gtk3-macros/src/lib.rs
+++ b/gtk3-macros/src/lib.rs
@@ -1,0 +1,14 @@
+mod composite_template_derive;
+mod util;
+
+use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(CompositeTemplate, attributes(template_child))]
+#[proc_macro_error]
+pub fn composite_template_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let gen = composite_template_derive::impl_composite_template(&input);
+    gen.into()
+}

--- a/gtk3-macros/src/util.rs
+++ b/gtk3-macros/src/util.rs
@@ -1,0 +1,82 @@
+use anyhow::{bail, Result};
+use itertools::Itertools;
+use proc_macro2::{Ident, Span};
+use proc_macro_crate::crate_name;
+use syn::{Attribute, Lit, Meta, MetaList, NestedMeta};
+
+// find the #[@attr_name] attribute in @attrs
+fn find_attribute_meta(attrs: &[Attribute], attr_name: &str) -> Result<Option<MetaList>> {
+    let meta = match attrs.iter().find(|a| a.path.is_ident(attr_name)) {
+        Some(a) => a.parse_meta(),
+        _ => return Ok(None),
+    };
+    match meta? {
+        Meta::List(n) => Ok(Some(n)),
+        _ => bail!("wrong meta type"),
+    }
+}
+
+#[derive(Debug)]
+pub enum TemplateChildAttribute {
+    Id(String),
+}
+
+fn parse_attribute(meta: &NestedMeta) -> Result<(String, String)> {
+    let meta = match &meta {
+        NestedMeta::Meta(m) => m,
+        _ => bail!("wrong meta type: not a NestedMeta::Meta"),
+    };
+    let meta = match meta {
+        Meta::NameValue(n) => n,
+        _ => bail!("wrong meta type: not a Meta::NameValue"),
+    };
+    let value = match &meta.lit {
+        Lit::Str(s) => s.value(),
+        _ => bail!("wrong meta type: not a Lit::Str"),
+    };
+
+    let ident = match meta.path.get_ident() {
+        None => bail!("missing ident"),
+        Some(ident) => ident,
+    };
+
+    Ok((ident.to_string(), value))
+}
+
+fn parse_template_child_attribute(meta: &NestedMeta) -> Result<TemplateChildAttribute> {
+    let (ident, v) = parse_attribute(meta)?;
+
+    match ident.as_ref() {
+        "id" => Ok(TemplateChildAttribute::Id(v)),
+        s => bail!("Unknown item meta {}", s),
+    }
+}
+
+pub fn parse_template_child_attributes(
+    attr_name: &str,
+    attrs: &[Attribute],
+) -> Result<Vec<TemplateChildAttribute>> {
+    let meta_list = find_attribute_meta(attrs, attr_name)?;
+    let v = match meta_list {
+        Some(meta) => meta
+            .nested
+            .iter()
+            .map(|m| parse_template_child_attribute(&m))
+            .fold_results(Vec::new(), |mut v, a| {
+                v.push(a);
+                v
+            })?,
+        None => Vec::new(),
+    };
+
+    Ok(v)
+}
+
+pub fn crate_ident_new() -> Ident {
+    let crate_name = match crate_name("gtk") {
+        Ok(x) => x,
+        Err(_) => "gtk".to_owned(),
+    };
+
+    Ident::new(&crate_name, Span::call_site())
+}


### PR DESCRIPTION
Backports support for composite templates from gtk4-rs.

We can't use gtk-macros as the name of the proc macro crate due to a conflict with an existing gtk-macros crate.