### PR TITLE
pango: export Glyph* manual types

### DIFF
--- a/pango/src/lib.rs
+++ b/pango/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::language::Language;
 pub mod rectangle;
 pub use crate::rectangle::Rectangle;
 pub mod glyph;
-pub use glyph::{GlyphGeometry, GlyphInfo, GlyphItem, GlyphString};
+pub use glyph::{GlyphGeometry, GlyphInfo, GlyphString};
 
 mod coverage;
 pub use crate::coverage::*;

--- a/pango/src/lib.rs
+++ b/pango/src/lib.rs
@@ -56,7 +56,7 @@ pub use crate::language::Language;
 pub mod rectangle;
 pub use crate::rectangle::Rectangle;
 pub mod glyph;
-pub use glyph::{GlyphGeometry, GlyphInfo, GlyphString};
+pub use glyph::{GlyphGeometry, GlyphInfo};
 
 mod coverage;
 pub use crate::coverage::*;

--- a/pango/src/lib.rs
+++ b/pango/src/lib.rs
@@ -56,6 +56,7 @@ pub use crate::language::Language;
 pub mod rectangle;
 pub use crate::rectangle::Rectangle;
 pub mod glyph;
+pub use glyph::{GlyphGeometry, GlyphInfo, GlyphItem, GlyphString};
 
 mod coverage;
 pub use crate::coverage::*;


### PR DESCRIPTION
Otherwise gir produces code that uses `pango::Glyph*` which can't be found
```
error[E0412]: cannot find type `GlyphInfo` in crate `pango`
  --> gsk4/src/auto/text_node.rs:49:44
   |
49 |       pub fn get_glyphs(&self) -> Vec<pango::GlyphInfo> {
   |                                              ^^^^^^^^^
   | 
  ::: /home/bilelmoussaoui/.cargo/git/checkouts/gtk-rs-48ef14c1f17c79fb/0ef3630/pango/src/auto/glyph_item.rs:8:1
   |
8  | / glib::glib_wrapper! {
9  | |     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
10 | |     pub struct GlyphItem(Boxed<ffi::PangoGlyphItem>);
11 | |
...  |
16 | |     }
17 | | }
   | |_- similarly named struct `GlyphItem` defined here
   |
help: a struct with a similar name exists
   |
49 |     pub fn get_glyphs(&self) -> Vec<pango::GlyphItem> {
   |                                            ^^^^^^^^^
help: consider importing this struct
   |
5  | use pango::glyph::GlyphInfo;
   |
```