### PR TITLE
subclass: Hook up instance_init()

### DIFF
--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -281,5 +281,6 @@ pub use self::boxed::register_boxed_type;
 pub use self::interface::register_interface;
 pub use self::object::Property;
 pub use self::types::{
-    register_type, InitializingType, SignalClassHandlerToken, SignalInvocationHint, TypeData,
+    register_type, InitializingObject, InitializingType, SignalClassHandlerToken,
+    SignalInvocationHint, TypeData,
 };


### PR DESCRIPTION
Add a new wrapper type, `InitializingObject`, to store the object pointer during `instance_init()`. Binding crates are expected to define traits and implement them for `InitializingObject` to expose safe methods. Notably, this is required for `gtk_widget_init_template()`.