### PR TITLE
Consistently re-export subclassing preludes of dependency crates

### DIFF
--- a/gio/src/subclass/mod.rs
+++ b/gio/src/subclass/mod.rs
@@ -9,9 +9,11 @@ mod output_stream;
 mod seekable;
 
 pub use self::application::ArgumentList;
-pub use self::prelude::*;
 
 pub mod prelude {
+    #[doc(hidden)]
+    pub use glib::subclass::prelude::*;
+
     pub use super::application::{ApplicationImpl, ApplicationImplExt};
     pub use super::input_stream::{InputStreamImpl, InputStreamImplExt};
     pub use super::io_stream::{IOStreamImpl, IOStreamImplExt};
@@ -19,5 +21,4 @@ pub mod prelude {
     pub use super::list_model::ListModelImpl;
     pub use super::output_stream::{OutputStreamImpl, OutputStreamImplExt};
     pub use super::seekable::SeekableImpl;
-    pub use glib::subclass::prelude::*;
 }

--- a/gtk/src/subclass/mod.rs
+++ b/gtk/src/subclass/mod.rs
@@ -33,6 +33,11 @@ pub mod widget;
 pub mod window;
 
 pub mod prelude {
+    #[doc(hidden)]
+    pub use gio::subclass::prelude::*;
+    #[doc(hidden)]
+    pub use glib::subclass::prelude::*;
+
     pub use super::application::{GtkApplicationImpl, GtkApplicationImplExt};
     pub use super::application_window::ApplicationWindowImpl;
     pub use super::bin::BinImpl;
@@ -66,6 +71,4 @@ pub mod prelude {
         CompositeTemplate, TemplateChild, WidgetClassSubclassExt, WidgetImpl, WidgetImplExt,
     };
     pub use super::window::{WindowImpl, WindowImplExt};
-    pub use gio::subclass::prelude::*;
-    pub use glib::subclass::prelude::*;
 }


### PR DESCRIPTION
@bilelmoussaoui Same change is also needed for gtk4 I guess