### PR TITLE
update bitflags to 1.2 to fix macro namespace issues

### DIFF
--- a/atk/Cargo.toml
+++ b/atk/Cargo.toml
@@ -37,7 +37,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 ffi = { package = "atk-sys", path = "sys" }
 glib = { path = "../glib" }
 

--- a/cairo/Cargo.toml
+++ b/cairo/Cargo.toml
@@ -60,7 +60,7 @@ optional = true
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 thiserror = "1.0.10"
 
 [dev-dependencies]

--- a/gdk/Cargo.toml
+++ b/gdk/Cargo.toml
@@ -38,7 +38,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 ffi = { package = "gdk-sys", path = "sys" }
 cairo-rs = { path = "../cairo" }
 gdk-pixbuf = { path = "../gdk-pixbuf" }

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -45,7 +45,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 once_cell = "1.0"
 futures = "0.3"
 futures-core = "0.3"

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -20,7 +20,7 @@ name = "glib"
 [dependencies]
 once_cell = "1.0"
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 futures-core = "0.3"
 futures-task = "0.3"
 futures-executor = "0.3"

--- a/gtk/Cargo.toml
+++ b/gtk/Cargo.toml
@@ -52,7 +52,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 field-offset = "0.3"
 once_cell = "1.0"
 atk = { path = "../atk" }

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -34,7 +34,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 once_cell = "1.0"
 ffi = { package = "pango-sys", path = "sys" }
 glib = { path = "../glib" }

--- a/pangocairo/Cargo.toml
+++ b/pangocairo/Cargo.toml
@@ -30,7 +30,7 @@ git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.0"
+bitflags = "1.2"
 ffi = { package = "pangocairo-sys", path = "sys" }
 glib = { path = "../glib" }
 pango = { path = "../pango" }


### PR DESCRIPTION
Update bitflags from 1.0 to 1.2.

I was working with a project that was pulling in glib from github, and it kept failing because an bitflags-internal macro `__bitflags` was not in scope.  I'm not exactly sure why it's not always triggered, but it's something to do with 2018 edition and macro scopes.  It was fixed in bitflags PR 165.

It appears 1.2 has the same minimum rust version.  I don't see any reason not to update it.