### PR TITLE
object: Add a From<&mut $ffi_type>

### DIFF
--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -658,6 +658,20 @@ macro_rules! glib_object_wrapper {
             type GlibType = *mut $ffi_name;
         }
 
+        // This method isn't something most "pure Rust" users would need, so hide
+        // it from the docs.  One motivational use is combining gtk-rs with cxx-rs;
+        // the latter provides `Pin<&mut $ffitype>` rather than raw pointers.
+        #[doc(hidden)]
+        impl From<&mut $ffi_name> for $name {
+            fn from(r: &mut $ffi_name) -> $name {
+                // Safety: We are incrementing the refcount, so converting the
+                // reference into a raw pointer is OK.
+                unsafe {
+                    $name($crate::translate::from_glib_none(r as *mut $ffi_name as *mut $crate::object::GObject))
+                }
+            }
+        }
+
         #[doc(hidden)]
         unsafe impl $crate::object::ObjectType for $name {
             type GlibType = $ffi_name;


### PR DESCRIPTION
The use case for this is a bit obscure.  In rpm-ostree
we're combining glib-rs with https://cxx.rs - the latter supports
passing "external binding types" across its own FFI, such as types
created by `bindgen`.  It works equally well for glib-rs generated
types.

However, rather than passing raw pointers it provides `Pin<&mut $ffitype>`.
Add a `From<>` implementation that makes it convenient to go
from a reference of the FFI type to the wrapper.  This will allow
us to drop some custom wrapper glue defined per GObject type
in rpm-ostree.