### PR TITLE
glib: Add wrapper for `g_type_ensure`

### DIFF
--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -142,6 +142,13 @@ impl Type {
             }
         }
     }
+
+    #[doc(alias = "g_type_ensure")]
+    pub fn ensure(&self) {
+        unsafe {
+            gobject_ffi::g_type_ensure(self.to_glib());
+        }
+    }
 }
 
 impl fmt::Debug for Type {


### PR DESCRIPTION
Presumably this is needed for in Rust, like C, at least in certain cases. (Perhaps with types defined in another language, if not in Rust?)