### PR TITLE
Don't need serial_test_derive

### DIFF
--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -58,7 +58,6 @@ thiserror = "1"
 futures-util = { version = "0.3", features = ["io"] }
 gir-format-check = "^0.1"
 serial_test = "0.5"
-serial_test_derive = "0.5"
 
 [[test]]
 name = "futures"


### PR DESCRIPTION
`serial_test` since [0.3](https://github.com/palfrey/serial_test/releases/tag/v0.3.0) includes `serial_test_derive` and lets you use the macro without needing to directly include `serial_test_derive`