### PR TITLE
glib: Correctly mark future returned by ThreadPool::push_future() as …

### DIFF
--- a/glib/src/thread_pool.rs
+++ b/glib/src/thread_pool.rs
@@ -76,7 +76,7 @@ impl ThreadPool {
     pub fn push_future<T: Send + 'static, F: FnOnce() -> T + Send + 'static>(
         &self,
         func: F,
-    ) -> Result<impl Future<Output = T>, crate::Error> {
+    ) -> Result<impl Future<Output = T> + Send + Sync + 'static, crate::Error> {
         let (sender, receiver) = oneshot::channel();
 
         self.push(move || {


### PR DESCRIPTION
…Send+Sync+'static

----

It could've also been `Unpin` but because of the `async` block that's not possible anymore. Probably not much of a problem in practice. (CC @jplatte )