### PR TITLE
gdk: Use cairo::Format instead of i32 for the format in Window::creat…

### DIFF
--- a/gdk/Gir.toml
+++ b/gdk/Gir.toml
@@ -441,6 +441,10 @@ manual_traits = ["WindowExtManual"]
     [[object.function]]
     name = "create_similar_surface"
     manual = true
+    # See https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3228
+    [[object.function]]
+    name = "create_similar_image_surface"
+    manual = true
     [[object.function]]
     name = "set_opaque_region"
         [[object.function.parameter]]

--- a/gdk/src/auto/window.rs
+++ b/gdk/src/auto/window.rs
@@ -224,25 +224,6 @@ impl Window {
         }
     }
 
-    #[doc(alias = "gdk_window_create_similar_image_surface")]
-    pub fn create_similar_image_surface(
-        &self,
-        format: i32,
-        width: i32,
-        height: i32,
-        scale: i32,
-    ) -> Option<cairo::Surface> {
-        unsafe {
-            from_glib_full(ffi::gdk_window_create_similar_image_surface(
-                self.to_glib_none().0,
-                format,
-                width,
-                height,
-                scale,
-            ))
-        }
-    }
-
     #[doc(alias = "gdk_window_deiconify")]
     pub fn deiconify(&self) {
         unsafe {

--- a/gdk/src/window.rs
+++ b/gdk/src/window.rs
@@ -139,6 +139,25 @@ impl Window {
             ))
         }
     }
+
+    #[doc(alias = "gdk_window_create_similar_image_surface")]
+    pub fn create_similar_image_surface(
+        &self,
+        format: cairo::Format,
+        width: i32,
+        height: i32,
+        scale: i32,
+    ) -> Option<cairo::Surface> {
+        unsafe {
+            from_glib_full(ffi::gdk_window_create_similar_image_surface(
+                self.to_glib_none().0,
+                format.into(),
+                width,
+                height,
+                scale,
+            ))
+        }
+    }
 }
 
 pub trait WindowExtManual: 'static {


### PR DESCRIPTION
…e_similar_image_surface()

Fixes https://github.com/gtk-rs/gtk-rs/issues/297