### PR TITLE
gtk: Take (column, value) tuples instead of separate slices for the t…

### DIFF
--- a/examples/src/bin/entry_completion.rs
+++ b/examples/src/bin/entry_completion.rs
@@ -30,10 +30,9 @@ fn create_list_model() -> gtk::ListStore {
         },
     ];
     let store = gtk::ListStore::new(&col_types);
-    let col_indices: [u32; 1] = [0];
     for d in data.iter() {
-        let values: [&dyn ToValue; 1] = [&d.description];
-        store.set(&store.append(), &col_indices, &values);
+        let values: [(u32, &dyn ToValue); 1] = [(0, &d.description)];
+        store.set(&store.append(), &values);
     }
     store
 }

--- a/examples/src/bin/iconview_example.rs
+++ b/examples/src/bin/iconview_example.rs
@@ -53,10 +53,12 @@ fn create_list_store_model() -> gtk::ListStore {
                     icon_view_model.insert_with_values(
                         None,
                         &[
-                            IconViewColumnType::TextColumn as u32,
-                            IconViewColumnType::PixbufColumn as u32,
+                            (
+                                IconViewColumnType::TextColumn as u32,
+                                &String::from("Label"),
+                            ),
+                            (IconViewColumnType::PixbufColumn as u32, &r),
                         ],
-                        &[&String::from("Label"), &r],
                     );
                 }
                 Err(err) => {

--- a/examples/src/bin/list_store.rs
+++ b/examples/src/bin/list_store.rs
@@ -169,8 +169,6 @@ fn create_model() -> gtk::ListStore {
 
     let store = gtk::ListStore::new(&col_types);
 
-    let col_indices: [u32; 8] = [0, 1, 2, 3, 4, 5, 6, 7];
-
     for (d_idx, d) in data.iter().enumerate() {
         let icon_name = if d_idx == 1 || d_idx == 3 {
             "battery-caution-charging-symbolic"
@@ -180,17 +178,17 @@ fn create_model() -> gtk::ListStore {
 
         let sensitive = d_idx != 3;
 
-        let values: [&dyn ToValue; 8] = [
-            &d.fixed,
-            &d.number,
-            &d.severity,
-            &d.description,
-            &0u32,
-            &icon_name,
-            &false,
-            &sensitive,
+        let values: [(u32, &dyn ToValue); 8] = [
+            (0, &d.fixed),
+            (1, &d.number),
+            (2, &d.severity),
+            (3, &d.description),
+            (4, &0u32),
+            (5, &icon_name),
+            (6, &false),
+            (7, &sensitive),
         ];
-        store.set(&store.append(), &col_indices, &values);
+        store.set(&store.append(), &values);
     }
 
     store

--- a/examples/src/bin/simple_treeview.rs
+++ b/examples/src/bin/simple_treeview.rs
@@ -17,7 +17,7 @@ fn create_and_fill_model() -> ListStore {
     // Filling up the tree view.
     let entries = &["Michel", "Sara", "Liam", "Zelda", "Neo", "Octopus master"];
     for (i, entry) in entries.iter().enumerate() {
-        model.insert_with_values(None, &[0, 1], &[&(i as u32 + 1), &entry]);
+        model.insert_with_values(None, &[(0, &(i as u32 + 1)), (1, &entry)]);
     }
     model
 }

--- a/examples/src/bin/tree_model_sort.rs
+++ b/examples/src/bin/tree_model_sort.rs
@@ -15,10 +15,10 @@ fn build_ui(application: &gtk::Application) {
     window.set_default_size(350, 70);
 
     let store = gtk::TreeStore::new(&[glib::Type::String]);
-    store.insert_with_values(None, None, &[0], &[&"One"]);
-    store.insert_with_values(None, None, &[0], &[&"Two"]);
-    store.insert_with_values(None, None, &[0], &[&"Three"]);
-    store.insert_with_values(None, None, &[0], &[&"Four"]);
+    store.insert_with_values(None, None, &[(0, &"One")]);
+    store.insert_with_values(None, None, &[(0, &"Two")]);
+    store.insert_with_values(None, None, &[(0, &"Three")]);
+    store.insert_with_values(None, None, &[(0, &"Four")]);
 
     // We create the `TreeModelSort` and we give it the `TreeStore` as
     // parameter.

--- a/examples/src/bin/treeview.rs
+++ b/examples/src/bin/treeview.rs
@@ -36,13 +36,13 @@ fn build_ui(application: &gtk::Application) {
     append_text_column(&left_tree);
 
     for i in 0..10 {
-        // insert_with_values takes two slices: column indices and ToValue
+        // insert_with_values takes a slice of tuples: column index and ToValue
         // trait objects. ToValue is implemented for strings, numeric types,
         // bool and Object descendants
-        let iter = left_store.insert_with_values(None, None, &[0], &[&format!("Hello {}", i)]);
+        let iter = left_store.insert_with_values(None, None, &[(0, &format!("Hello {}", i))]);
 
         for _ in 0..i {
-            left_store.insert_with_values(Some(&iter), None, &[0], &[&"I'm a child node"]);
+            left_store.insert_with_values(Some(&iter), None, &[(0, &"I'm a child node")]);
         }
     }
 
@@ -84,8 +84,7 @@ fn build_ui(application: &gtk::Application) {
         right_store.insert_with_values(
             None,
             None,
-            &[0, 1],
-            &[&image, &"I'm a child node with an image"],
+            &[(0, &image), (1, &"I'm a child node with an image")],
         );
     }
 

--- a/gtk/src/list_store.rs
+++ b/gtk/src/list_store.rs
@@ -28,15 +28,14 @@ pub trait GtkListStoreExtManual: 'static {
     fn insert_with_values(
         &self,
         position: Option<u32>,
-        columns: &[u32],
-        values: &[&dyn ToValue],
+        columns_and_values: &[(u32, &dyn ToValue)],
     ) -> TreeIter;
 
     #[doc(alias = "gtk_list_store_reorder")]
     fn reorder(&self, new_order: &[u32]);
 
     #[doc(alias = "gtk_list_store_set")]
-    fn set(&self, iter: &TreeIter, columns: &[u32], values: &[&dyn ToValue]);
+    fn set(&self, iter: &TreeIter, columns_and_values: &[(u32, &dyn ToValue)]);
 
     #[doc(alias = "gtk_list_store_set_value")]
     fn set_value(&self, iter: &TreeIter, column: u32, value: &Value);
@@ -46,31 +45,59 @@ impl<O: IsA<ListStore>> GtkListStoreExtManual for O {
     fn insert_with_values(
         &self,
         position: Option<u32>,
-        columns: &[u32],
-        values: &[&dyn ToValue],
+        columns_and_values: &[(u32, &dyn ToValue)],
     ) -> TreeIter {
         unsafe {
-            assert!(position.unwrap_or(0) <= i32::max_value() as u32);
-            assert_eq!(columns.len(), values.len());
+            assert!(
+                position.unwrap_or(0) <= i32::max_value() as u32,
+                "can't have more than {} rows",
+                i32::max_value()
+            );
             let n_columns = ffi::gtk_tree_model_get_n_columns(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
             ) as u32;
-            assert!(columns.len() <= n_columns as usize);
-            for (&column, value) in columns.iter().zip(values.iter()) {
-                assert!(column < n_columns);
+            assert!(
+                columns_and_values.len() <= n_columns as usize,
+                "got values for {} columns but only {} columns exist",
+                columns_and_values.len(),
+                n_columns
+            );
+            for (column, value) in columns_and_values {
+                assert!(
+                    *column < n_columns,
+                    "got column {} which is higher than the number of columns {}",
+                    *column,
+                    n_columns
+                );
                 let type_ = from_glib(ffi::gtk_tree_model_get_column_type(
                     self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
-                    column as c_int,
+                    *column as c_int,
                 ));
-                assert!(Value::type_transformable(value.to_value_type(), type_));
+                assert!(
+                    Value::type_transformable(value.to_value_type(), type_),
+                    "column {} is of type {} but found value of type {}",
+                    *column,
+                    type_,
+                    value.to_value_type()
+                );
             }
+
+            let columns = columns_and_values
+                .iter()
+                .map(|(c, _)| *c)
+                .collect::<Vec<_>>();
+            let values = columns_and_values
+                .iter()
+                .map(|(_, v)| v.to_value())
+                .collect::<Vec<_>>();
+
             let mut iter = TreeIter::uninitialized();
             ffi::gtk_list_store_insert_with_valuesv(
                 self.as_ref().to_glib_none().0,
                 iter.to_glib_none_mut().0,
                 position.map_or(-1, |n| n as c_int),
                 mut_override(columns.as_ptr() as *const c_int),
-                values.to_glib_none().0,
+                mut_override(values.as_ptr() as *const glib::gobject_ffi::GValue),
                 columns.len() as c_int,
             );
             iter
@@ -110,26 +137,51 @@ impl<O: IsA<ListStore>> GtkListStoreExtManual for O {
         }
     }
 
-    fn set(&self, iter: &TreeIter, columns: &[u32], values: &[&dyn ToValue]) {
+    fn set(&self, iter: &TreeIter, columns_and_values: &[(u32, &dyn ToValue)]) {
         unsafe {
-            assert_eq!(columns.len(), values.len());
             let n_columns = ffi::gtk_tree_model_get_n_columns(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
             ) as u32;
-            assert!(columns.len() <= n_columns as usize);
-            for (&column, value) in columns.iter().zip(values.iter()) {
-                assert!(column < n_columns);
+            assert!(
+                columns_and_values.len() <= n_columns as usize,
+                "got values for {} columns but only {} columns exist",
+                columns_and_values.len(),
+                n_columns
+            );
+            for (column, value) in columns_and_values {
+                assert!(
+                    *column < n_columns,
+                    "got column {} which is higher than the number of columns {}",
+                    *column,
+                    n_columns
+                );
                 let type_ = from_glib(ffi::gtk_tree_model_get_column_type(
                     self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
-                    column as c_int,
+                    *column as c_int,
                 ));
-                assert!(Value::type_transformable(value.to_value_type(), type_));
+                assert!(
+                    Value::type_transformable(value.to_value_type(), type_),
+                    "column {} is of type {} but found value of type {}",
+                    *column,
+                    type_,
+                    value.to_value_type()
+                );
             }
+
+            let columns = columns_and_values
+                .iter()
+                .map(|(c, _)| *c)
+                .collect::<Vec<_>>();
+            let values = columns_and_values
+                .iter()
+                .map(|(_, v)| v.to_value())
+                .collect::<Vec<_>>();
+
             ffi::gtk_list_store_set_valuesv(
                 self.as_ref().to_glib_none().0,
                 mut_override(iter.to_glib_none().0),
                 mut_override(columns.as_ptr() as *const c_int),
-                values.to_glib_none().0,
+                mut_override(values.as_ptr() as *const glib::gobject_ffi::GValue),
                 columns.len() as c_int,
             );
         }
@@ -139,13 +191,26 @@ impl<O: IsA<ListStore>> GtkListStoreExtManual for O {
         unsafe {
             let columns = ffi::gtk_tree_model_get_n_columns(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
+            ) as u32;
+            assert!(
+                column < columns,
+                "got column {} which is higher than the number of columns {}",
+                column,
+                columns
             );
-            assert!(column < columns as u32);
+
             let type_ = from_glib(ffi::gtk_tree_model_get_column_type(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
                 column as c_int,
             ));
-            assert!(Value::type_transformable(value.type_(), type_));
+            assert!(
+                Value::type_transformable(value.type_(), type_),
+                "column {} is of type {} but found value of type {}",
+                column,
+                type_,
+                value.type_()
+            );
+
             ffi::gtk_list_store_set_value(
                 self.as_ref().to_glib_none().0,
                 mut_override(iter.to_glib_none().0),

--- a/gtk/src/tree_store.rs
+++ b/gtk/src/tree_store.rs
@@ -28,15 +28,14 @@ pub trait TreeStoreExtManual: 'static {
         &self,
         parent: Option<&TreeIter>,
         position: Option<u32>,
-        columns: &[u32],
-        values: &[&dyn ToValue],
+        columns_and_values: &[(u32, &dyn ToValue)],
     ) -> TreeIter;
 
     #[doc(alias = "gtk_tree_store_reorder")]
     fn reorder(&self, parent: &TreeIter, new_order: &[u32]);
 
     #[doc(alias = "gtk_tree_store_set")]
-    fn set(&self, iter: &TreeIter, columns: &[u32], values: &[&dyn ToValue]);
+    fn set(&self, iter: &TreeIter, columns_and_values: &[(u32, &dyn ToValue)]);
 
     #[doc(alias = "gtk_tree_store_set_value")]
     fn set_value(&self, iter: &TreeIter, column: u32, value: &Value);
@@ -47,23 +46,52 @@ impl<O: IsA<TreeStore>> TreeStoreExtManual for O {
         &self,
         parent: Option<&TreeIter>,
         position: Option<u32>,
-        columns: &[u32],
-        values: &[&dyn ToValue],
+        columns_and_values: &[(u32, &dyn ToValue)],
     ) -> TreeIter {
         unsafe {
-            assert!(position.unwrap_or(0) <= i32::max_value() as u32);
-            assert_eq!(columns.len(), values.len());
+            assert!(
+                position.unwrap_or(0) <= i32::max_value() as u32,
+                "can't have more than {} rows",
+                i32::max_value()
+            );
             let n_columns = ffi::gtk_tree_model_get_n_columns(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
             ) as u32;
-            assert!(columns.len() <= n_columns as usize);
-            for (&column, value) in columns.iter().zip(values.iter()) {
+            assert!(
+                columns_and_values.len() <= n_columns as usize,
+                "got values for {} columns but only {} columns exist",
+                columns_and_values.len(),
+                n_columns
+            );
+            for (column, value) in columns_and_values {
+                assert!(
+                    *column < n_columns,
+                    "got column {} which is higher than the number of columns {}",
+                    *column,
+                    n_columns
+                );
                 let type_ = from_glib(ffi::gtk_tree_model_get_column_type(
                     self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
-                    column as c_int,
+                    *column as c_int,
                 ));
-                assert!(Value::type_transformable(value.to_value_type(), type_));
+                assert!(
+                    Value::type_transformable(value.to_value_type(), type_),
+                    "column {} is of type {} but found value of type {}",
+                    *column,
+                    type_,
+                    value.to_value_type()
+                );
             }
+
+            let columns = columns_and_values
+                .iter()
+                .map(|(c, _)| *c)
+                .collect::<Vec<_>>();
+            let values = columns_and_values
+                .iter()
+                .map(|(_, v)| v.to_value())
+                .collect::<Vec<_>>();
+
             let mut iter = TreeIter::uninitialized();
             ffi::gtk_tree_store_insert_with_valuesv(
                 self.as_ref().to_glib_none().0,
@@ -71,7 +99,7 @@ impl<O: IsA<TreeStore>> TreeStoreExtManual for O {
                 mut_override(parent.to_glib_none().0),
                 position.map_or(-1, |n| n as c_int),
                 mut_override(columns.as_ptr() as *const c_int),
-                values.to_glib_none().0,
+                mut_override(values.as_ptr() as *const glib::gobject_ffi::GValue),
                 columns.len() as c_int,
             );
             iter
@@ -112,26 +140,51 @@ impl<O: IsA<TreeStore>> TreeStoreExtManual for O {
         }
     }
 
-    fn set(&self, iter: &TreeIter, columns: &[u32], values: &[&dyn ToValue]) {
+    fn set(&self, iter: &TreeIter, columns_and_values: &[(u32, &dyn ToValue)]) {
         unsafe {
-            assert_eq!(columns.len(), values.len());
             let n_columns = ffi::gtk_tree_model_get_n_columns(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
             ) as u32;
-            assert!(columns.len() <= n_columns as usize);
-            for (&column, value) in columns.iter().zip(values.iter()) {
-                assert!(column < n_columns);
+            assert!(
+                columns_and_values.len() <= n_columns as usize,
+                "got values for {} columns but only {} columns exist",
+                columns_and_values.len(),
+                n_columns
+            );
+            for (column, value) in columns_and_values {
+                assert!(
+                    *column < n_columns,
+                    "got column {} which is higher than the number of columns {}",
+                    *column,
+                    n_columns
+                );
                 let type_ = from_glib(ffi::gtk_tree_model_get_column_type(
                     self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
-                    column as c_int,
+                    *column as c_int,
                 ));
-                assert!(Value::type_transformable(value.to_value_type(), type_));
+                assert!(
+                    Value::type_transformable(value.to_value_type(), type_),
+                    "column {} is of type {} but found value of type {}",
+                    *column,
+                    type_,
+                    value.to_value_type()
+                );
             }
+
+            let columns = columns_and_values
+                .iter()
+                .map(|(c, _)| *c)
+                .collect::<Vec<_>>();
+            let values = columns_and_values
+                .iter()
+                .map(|(_, v)| v.to_value())
+                .collect::<Vec<_>>();
+
             ffi::gtk_tree_store_set_valuesv(
                 self.as_ref().to_glib_none().0,
                 mut_override(iter.to_glib_none().0),
                 mut_override(columns.as_ptr() as *const c_int),
-                values.to_glib_none().0,
+                mut_override(values.as_ptr() as *const glib::gobject_ffi::GValue),
                 columns.len() as c_int,
             );
         }
@@ -141,13 +194,26 @@ impl<O: IsA<TreeStore>> TreeStoreExtManual for O {
         unsafe {
             let columns = ffi::gtk_tree_model_get_n_columns(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
+            ) as u32;
+            assert!(
+                column < columns,
+                "got column {} which is higher than the number of columns {}",
+                column,
+                columns
             );
-            assert!(column < columns as u32);
+
             let type_ = from_glib(ffi::gtk_tree_model_get_column_type(
                 self.as_ref().upcast_ref::<TreeModel>().to_glib_none().0,
                 column as c_int,
             ));
-            assert!(Value::type_transformable(value.type_(), type_));
+            assert!(
+                Value::type_transformable(value.type_(), type_),
+                "column {} is of type {} but found value of type {}",
+                column,
+                type_,
+                value.type_()
+            );
+
             ffi::gtk_tree_store_set_value(
                 self.as_ref().to_glib_none().0,
                 mut_override(iter.to_glib_none().0),


### PR DESCRIPTION
…ree/list store setter/insertion function

This automatically ensures that there are as many columns as there are
values and makes the API closer to the C API, which takes varargs that
are column, value, column, value, etc.

Fixes https://github.com/gtk-rs/gtk-rs/issues/285