### PR TITLE
glib: Improve the API of Type

### DIFF
--- a/examples/src/bin/entry_completion.rs
+++ b/examples/src/bin/entry_completion.rs
@@ -13,7 +13,7 @@ struct Data {
 }
 
 fn create_list_model() -> gtk::ListStore {
-    let col_types: [glib::Type; 1] = [glib::Type::String];
+    let col_types: [glib::Type; 1] = [glib::Type::STRING];
 
     let data: [Data; 4] = [
         Data {

--- a/examples/src/bin/iconview_example.rs
+++ b/examples/src/bin/iconview_example.rs
@@ -31,7 +31,7 @@ fn create_list_store_model() -> gtk::ListStore {
 
     // Initialize an array of column types for ListStore object. Here we say that the first item
     // must always be of glib::Type String and the second item is of glib::Type Pixbuf.
-    let col_types: [glib::Type; 2] = [glib::Type::String, gdk_pixbuf::Pixbuf::static_type()];
+    let col_types: [glib::Type; 2] = [glib::Type::STRING, gdk_pixbuf::Pixbuf::static_type()];
     let icon_view_model = gtk::ListStore::new(&col_types);
 
     // IconTheme provides a facility for looking up icons by name and size.

--- a/examples/src/bin/list_store.rs
+++ b/examples/src/bin/list_store.rs
@@ -69,14 +69,14 @@ struct Data {
 
 fn create_model() -> gtk::ListStore {
     let col_types: [glib::Type; 8] = [
-        glib::Type::Bool,
+        glib::Type::BOOL,
         glib::Type::U32,
-        glib::Type::String,
-        glib::Type::String,
+        glib::Type::STRING,
+        glib::Type::STRING,
         glib::Type::U32,
-        glib::Type::String,
-        glib::Type::Bool,
-        glib::Type::Bool,
+        glib::Type::STRING,
+        glib::Type::BOOL,
+        glib::Type::BOOL,
     ];
 
     let data: [Data; 14] = [

--- a/examples/src/bin/tree_model_sort.rs
+++ b/examples/src/bin/tree_model_sort.rs
@@ -14,7 +14,7 @@ fn build_ui(application: &gtk::Application) {
     window.set_position(gtk::WindowPosition::Center);
     window.set_default_size(350, 70);
 
-    let store = gtk::TreeStore::new(&[glib::Type::String]);
+    let store = gtk::TreeStore::new(&[glib::Type::STRING]);
     store.insert_with_values(None, None, &[(0, &"One")]);
     store.insert_with_values(None, None, &[(0, &"Two")]);
     store.insert_with_values(None, None, &[(0, &"Three")]);

--- a/gio/src/subclass/list_model.rs
+++ b/gio/src/subclass/list_model.rs
@@ -86,7 +86,7 @@ where
     if let Some(ref i) = item {
         let type_ = imp.get_item_type(wrap.unsafe_cast_ref());
         assert!(
-            type_.is_a(&i.get_type()),
+            type_.is_a(i.get_type()),
             "All ListModel items should be of the same type"
         );
     };

--- a/gio/src/task.rs
+++ b/gio/src/task.rs
@@ -81,7 +81,7 @@ impl Task {
             let value = from_glib_full(value as *mut glib::gobject_ffi::GValue);
             match value {
                 Some(value) => Ok(value),
-                None => Ok(glib::Value::from_type(glib::types::Type::Unit)),
+                None => Ok(glib::Value::from_type(glib::types::Type::UNIT)),
             }
         }
     }

--- a/glib-macros/src/gboxed_derive.rs
+++ b/glib-macros/src/gboxed_derive.rs
@@ -97,7 +97,7 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
             const NAME: &'static str = #gtype_name;
 
             fn get_type() -> #crate_ident::Type {
-                static mut TYPE_: #crate_ident::Type = #crate_ident::Type::Invalid;
+                static mut TYPE_: #crate_ident::Type = #crate_ident::Type::INVALID;
                 static ONCE: ::std::sync::Once = ::std::sync::Once::new();
 
                 ONCE.call_once(|| {

--- a/glib-macros/src/gboxed_derive.rs
+++ b/glib-macros/src/gboxed_derive.rs
@@ -107,7 +107,10 @@ pub fn impl_gboxed(input: &syn::DeriveInput) -> TokenStream {
                     }
                 });
 
-                unsafe { TYPE_ }
+                unsafe {
+                    assert!(TYPE_.is_valid());
+                    TYPE_
+                }
             }
         }
 

--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -149,7 +149,7 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
 
         fn #get_type() -> #crate_ident::Type {
             static ONCE: std::sync::Once = std::sync::Once::new();
-            static mut TYPE: #crate_ident::Type = #crate_ident::Type::Invalid;
+            static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
 
             ONCE.call_once(|| {
                 static mut VALUES: [#crate_ident::gobject_ffi::GEnumValue; #nb_genum_values] = [
@@ -169,7 +169,7 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
             });
 
             unsafe {
-                assert_ne!(TYPE, #crate_ident::Type::Invalid);
+                assert_ne!(TYPE, #crate_ident::Type::INVALID);
                 TYPE
             }
         }

--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -169,7 +169,7 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
             });
 
             unsafe {
-                assert_ne!(TYPE, #crate_ident::Type::INVALID);
+                assert!(TYPE.is_valid());
                 TYPE
             }
         }

--- a/glib-macros/src/gflags_attribute.rs
+++ b/glib-macros/src/gflags_attribute.rs
@@ -183,7 +183,7 @@ pub fn impl_gflags(input: &DeriveInput, gtype_name: &LitStr) -> TokenStream {
             });
 
             unsafe {
-                assert_ne!(TYPE, #crate_ident::Type::INVALID);
+                assert!(TYPE.is_valid());
                 TYPE
             }
         }

--- a/glib-macros/src/gflags_attribute.rs
+++ b/glib-macros/src/gflags_attribute.rs
@@ -163,7 +163,7 @@ pub fn impl_gflags(input: &DeriveInput, gtype_name: &LitStr) -> TokenStream {
 
         fn #get_type() -> #crate_ident::Type {
             static ONCE: std::sync::Once = std::sync::Once::new();
-            static mut TYPE: #crate_ident::Type = #crate_ident::Type::Invalid;
+            static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
 
             ONCE.call_once(|| {
                 static mut VALUES: [#crate_ident::gobject_ffi::GFlagsValue; #nb_gflags_values] = [
@@ -183,7 +183,7 @@ pub fn impl_gflags(input: &DeriveInput, gtype_name: &LitStr) -> TokenStream {
             });
 
             unsafe {
-                assert_ne!(TYPE, #crate_ident::Type::Invalid);
+                assert_ne!(TYPE, #crate_ident::Type::INVALID);
                 TYPE
             }
         }

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -43,7 +43,7 @@ fn derive_genum() {
     );
 
     let t = Animal::static_type();
-    assert!(t.is_a(&glib::Type::ENUM));
+    assert!(t.is_a(glib::Type::ENUM));
     assert_eq!(t.name(), "TestAnimalType");
 
     let e = glib::EnumClass::new(t).expect("EnumClass::new failed");
@@ -134,7 +134,7 @@ fn attr_gflags() {
     );
 
     let t = MyFlags::static_type();
-    assert!(t.is_a(&glib::Type::FLAGS));
+    assert!(t.is_a(glib::Type::FLAGS));
     assert_eq!(t.name(), "MyFlags");
 
     let e = glib::FlagsClass::new(t).expect("FlagsClass::new failed");

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -43,7 +43,7 @@ fn derive_genum() {
     );
 
     let t = Animal::static_type();
-    assert!(t.is_a(&glib::Type::Enum));
+    assert!(t.is_a(&glib::Type::ENUM));
     assert_eq!(t.name(), "TestAnimalType");
 
     let e = glib::EnumClass::new(t).expect("EnumClass::new failed");
@@ -134,7 +134,7 @@ fn attr_gflags() {
     );
 
     let t = MyFlags::static_type();
-    assert!(t.is_a(&glib::Type::Flags));
+    assert!(t.is_a(&glib::Type::FLAGS));
     assert_eq!(t.name(), "MyFlags");
 
     let e = glib::FlagsClass::new(t).expect("FlagsClass::new failed");

--- a/glib/src/closure.rs
+++ b/glib/src/closure.rs
@@ -114,7 +114,7 @@ impl Closure {
             result
         };
 
-        if result.type_() == Type::Invalid {
+        if result.type_() == Type::INVALID {
             None
         } else {
             Some(result)

--- a/glib/src/closure.rs
+++ b/glib/src/closure.rs
@@ -9,7 +9,6 @@ use std::slice;
 use libc::{c_uint, c_void};
 
 use crate::translate::{from_glib_none, mut_override, ToGlibPtr, ToGlibPtrMut, Uninitialized};
-use crate::types::Type;
 use crate::ToValue;
 use crate::Value;
 
@@ -114,11 +113,7 @@ impl Closure {
             result
         };
 
-        if result.type_() == Type::INVALID {
-            None
-        } else {
-            Some(result)
-        }
+        Some(result).filter(|r| r.type_().is_valid())
     }
 }
 

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1519,15 +1519,13 @@ impl<T: ObjectType> ObjectExt for T {
             );
 
             // This can't really happen unless something goes wrong inside GObject
-            if value.type_() == crate::Type::INVALID {
-                Err(bool_error!(
+            Some(value).filter(|v| v.type_().is_valid()).ok_or_else(|| {
+                bool_error!(
                     "Failed to get property value for property '{}' of type '{}'",
                     property_name,
                     self.get_type()
-                ))
-            } else {
-                Ok(value)
-            }
+                )
+            })
         }
     }
 
@@ -1886,11 +1884,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
-                Ok(Some(return_value))
-            } else {
-                Ok(None)
-            }
+            Ok(Some(return_value).filter(|r| r.type_().is_valid() && r.type_() != Type::UNIT))
         }
     }
 
@@ -1939,11 +1933,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
-                Ok(Some(return_value))
-            } else {
-                Ok(None)
-            }
+            Ok(Some(return_value).filter(|r| r.type_().is_valid() && r.type_() != Type::UNIT))
         }
     }
 
@@ -2029,11 +2019,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
-                Ok(Some(return_value))
-            } else {
-                Ok(None)
-            }
+            Ok(Some(return_value).filter(|r| r.type_().is_valid() && r.type_() != Type::UNIT))
         }
     }
 
@@ -2091,11 +2077,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
-                Ok(Some(return_value))
-            } else {
-                Ok(None)
-            }
+            Ok(Some(return_value).filter(|r| r.type_().is_valid() && r.type_() != Type::UNIT))
         }
     }
 }

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1519,7 +1519,7 @@ impl<T: ObjectType> ObjectExt for T {
             );
 
             // This can't really happen unless something goes wrong inside GObject
-            if value.type_() == crate::Type::Invalid {
+            if value.type_() == crate::Type::INVALID {
                 Err(bool_error!(
                     "Failed to get property value for property '{}' of type '{}'",
                     property_name,
@@ -1763,7 +1763,7 @@ impl<T: ObjectType> ObjectExt for T {
         let closure = Closure::new_unsafe(move |values| {
             let ret = callback(values);
 
-            if return_type == Type::Unit {
+            if return_type == Type::UNIT {
                 if let Some(ret) = ret {
                     panic!(
                         "Signal '{}' of type '{}' required no return value but got value of type '{}'",
@@ -1872,7 +1872,7 @@ impl<T: ObjectType> ObjectExt for T {
             let signal_detail = validate_signal_arguments(type_, &signal_query, &mut args[1..])?;
 
             let mut return_value = Value::uninitialized();
-            if signal_query.return_type() != Type::Unit {
+            if signal_query.return_type() != Type::UNIT {
                 gobject_ffi::g_value_init(
                     return_value.to_glib_none_mut().0,
                     signal_query.return_type().to_glib(),
@@ -1886,7 +1886,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != Type::Unit && return_value.type_() != Type::Invalid {
+            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
                 Ok(Some(return_value))
             } else {
                 Ok(None)
@@ -1925,7 +1925,7 @@ impl<T: ObjectType> ObjectExt for T {
             validate_signal_arguments(type_, &signal_query, &mut args)?;
 
             let mut return_value = Value::uninitialized();
-            if signal_query.return_type() != crate::Type::Unit {
+            if signal_query.return_type() != Type::UNIT {
                 gobject_ffi::g_value_init(
                     return_value.to_glib_none_mut().0,
                     signal_query.return_type().to_glib(),
@@ -1939,9 +1939,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != crate::Type::Unit
-                && return_value.type_() != crate::Type::Invalid
-            {
+            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
                 Ok(Some(return_value))
             } else {
                 Ok(None)
@@ -2017,7 +2015,7 @@ impl<T: ObjectType> ObjectExt for T {
             let signal_detail = validate_signal_arguments(type_, &signal_query, &mut args[1..])?;
 
             let mut return_value = Value::uninitialized();
-            if signal_query.return_type() != Type::Unit {
+            if signal_query.return_type() != Type::UNIT {
                 gobject_ffi::g_value_init(
                     return_value.to_glib_none_mut().0,
                     signal_query.return_type().to_glib(),
@@ -2031,7 +2029,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != Type::Unit && return_value.type_() != Type::Invalid {
+            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
                 Ok(Some(return_value))
             } else {
                 Ok(None)
@@ -2079,7 +2077,7 @@ impl<T: ObjectType> ObjectExt for T {
             validate_signal_arguments(type_, &signal_query, &mut args)?;
 
             let mut return_value = Value::uninitialized();
-            if signal_query.return_type() != crate::Type::Unit {
+            if signal_query.return_type() != Type::UNIT {
                 gobject_ffi::g_value_init(
                     return_value.to_glib_none_mut().0,
                     signal_query.return_type().to_glib(),
@@ -2093,9 +2091,7 @@ impl<T: ObjectType> ObjectExt for T {
                 return_value.to_glib_none_mut().0,
             );
 
-            if return_value.type_() != crate::Type::Unit
-                && return_value.type_() != crate::Type::Invalid
-            {
+            if return_value.type_() != Type::UNIT && return_value.type_() != Type::INVALID {
                 Ok(Some(return_value))
             } else {
                 Ok(None)

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1135,7 +1135,7 @@ impl Object {
         type_: Type,
         params: &[(std::ffi::CString, Value)],
     ) -> Result<Object, BoolError> {
-        if !type_.is_a(&Object::static_type()) {
+        if !type_.is_a(Object::static_type()) {
             return Err(bool_error!(
                 "Can't instantiate non-GObject type '{}'",
                 type_
@@ -1169,7 +1169,7 @@ impl Object {
         );
         if ptr.is_null() {
             Err(bool_error!("Can't instantiate object for type '{}'", type_))
-        } else if type_.is_a(&InitiallyUnowned::static_type()) {
+        } else if type_.is_a(InitiallyUnowned::static_type()) {
             // Attention: This takes ownership of the floating reference
             Ok(from_glib_none(ptr))
         } else {
@@ -1333,7 +1333,7 @@ pub trait ObjectExt: ObjectType {
 
 impl<T: ObjectType> ObjectExt for T {
     fn is<U: StaticType>(&self) -> bool {
-        self.get_type().is_a(&U::static_type())
+        self.get_type().is_a(U::static_type())
     }
 
     fn get_type(&self) -> Type {
@@ -1785,10 +1785,10 @@ impl<T: ObjectType> ObjectExt for T {
                         // actual typed of the contained object is compatible and if so create
                         // a properly typed Value. This can happen if the type field in the
                         // Value is set to a more generic type than the contained value
-                        if !valid_type && ret.type_().is_a(&Object::static_type()) {
+                        if !valid_type && ret.type_().is_a(Object::static_type()) {
                             match ret.get::<Object>() {
                                 Ok(Some(obj)) => {
-                                    if obj.get_type().is_a(&return_type) {
+                                    if obj.get_type().is_a(return_type) {
                                         ret.0.g_type = return_type.to_glib();
                                     } else {
                                         panic!(
@@ -2135,10 +2135,10 @@ fn validate_property_type(
         // actual type of the contained object is compatible and if so create
         // a properly typed Value. This can happen if the type field in the
         // Value is set to a more generic type than the contained value
-        if !valid_type && property_value.type_().is_a(&Object::static_type()) {
+        if !valid_type && property_value.type_().is_a(Object::static_type()) {
             match property_value.get::<Object>() {
                 Ok(Some(obj)) => {
-                    if obj.get_type().is_a(&pspec.get_value_type()) {
+                    if obj.get_type().is_a(pspec.get_value_type()) {
                         property_value.0.g_type = pspec.get_value_type().to_glib();
                     } else {
                         return Err(
@@ -2212,10 +2212,10 @@ fn validate_signal_arguments(
 
     for (i, (arg, param_type)) in param_types.enumerate() {
         let param_type: Type = param_type.into();
-        if arg.type_().is_a(&Object::static_type()) {
+        if arg.type_().is_a(Object::static_type()) {
             match arg.get::<Object>() {
                 Ok(Some(obj)) => {
-                    if obj.get_type().is_a(&param_type) {
+                    if obj.get_type().is_a(param_type) {
                         arg.0.g_type = param_type.to_glib();
                     } else {
                         return Err(
@@ -2579,7 +2579,7 @@ impl<T: ObjectType> Class<T> {
     where
         U: IsA<T>,
     {
-        if !self.get_type().is_a(&U::static_type()) {
+        if !self.get_type().is_a(U::static_type()) {
             return None;
         }
 
@@ -2595,7 +2595,7 @@ impl<T: ObjectType> Class<T> {
     where
         U: IsA<T>,
     {
-        if !self.get_type().is_a(&U::static_type()) {
+        if !self.get_type().is_a(U::static_type()) {
             return None;
         }
 
@@ -2609,7 +2609,7 @@ impl<T: ObjectType> Class<T> {
     ///
     /// This will return `None` if `type_` is not a subclass of `Self`.
     pub fn from_type(type_: Type) -> Option<ClassRef<T>> {
-        if !type_.is_a(&T::static_type()) {
+        if !type_.is_a(T::static_type()) {
             return None;
         }
 

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -1055,7 +1055,7 @@ mod tests {
         let default_value = pspec.get_default_value();
         assert_eq!(default_value.get::<&str>().unwrap(), Some("default"));
         assert_eq!(pspec.get_flags(), ParamFlags::READWRITE);
-        assert_eq!(pspec.get_value_type(), Type::String);
+        assert_eq!(pspec.get_value_type(), Type::STRING);
         assert_eq!(pspec.get_type(), ParamSpecString::static_type());
 
         let pspec_ref = pspec

--- a/glib/src/subclass/boxed.rs
+++ b/glib/src/subclass/boxed.rs
@@ -77,12 +77,12 @@ mod test {
 
     #[test]
     fn test_register() {
-        assert_ne!(crate::Type::Invalid, MyBoxed::get_type());
+        assert_ne!(crate::Type::INVALID, MyBoxed::get_type());
     }
 
     #[test]
     fn test_value() {
-        assert_ne!(crate::Type::Invalid, MyBoxed::get_type());
+        assert_ne!(crate::Type::INVALID, MyBoxed::get_type());
 
         let b = MyBoxed(String::from("abc"));
         let v = b.to_value();

--- a/glib/src/subclass/boxed.rs
+++ b/glib/src/subclass/boxed.rs
@@ -77,12 +77,12 @@ mod test {
 
     #[test]
     fn test_register() {
-        assert_ne!(crate::Type::INVALID, MyBoxed::get_type());
+        assert!(MyBoxed::get_type().is_valid());
     }
 
     #[test]
     fn test_value() {
-        assert_ne!(crate::Type::INVALID, MyBoxed::get_type());
+        assert!(MyBoxed::get_type().is_valid());
 
         let b = MyBoxed(String::from("abc"));
         let v = b.to_value();

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -28,7 +28,7 @@ macro_rules! object_interface {
     () => {
         fn get_type() -> $crate::Type {
             static ONCE: std::sync::Once = std::sync::Once::new();
-            static mut TYPE: $crate::Type = $crate::Type::Invalid;
+            static mut TYPE: $crate::Type = $crate::Type::INVALID;
 
             ONCE.call_once(|| {
                 let type_ = $crate::subclass::register_interface::<Self>();
@@ -38,7 +38,7 @@ macro_rules! object_interface {
             });
 
             unsafe {
-                assert_ne!(TYPE, $crate::Type::Invalid);
+                assert_ne!(TYPE, $crate::Type::INVALID);
 
                 TYPE
             }
@@ -165,7 +165,7 @@ pub fn register_interface<T: ObjectInterface>() -> Type {
         );
 
         let type_ = from_glib(gobject_ffi::g_type_register_static_simple(
-            Type::Interface.to_glib(),
+            Type::INTERFACE.to_glib(),
             type_name.as_ptr(),
             mem::size_of::<T>() as u32,
             Some(interface_init::<T>),

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -109,7 +109,7 @@ pub trait ObjectInterfaceExt: ObjectInterface {
     ///
     /// This will panic if `obj` does not implement the interface.
     fn from_instance<T: IsA<Object>>(obj: &T) -> &Self {
-        assert!(obj.as_ref().get_type().is_a(&Self::get_type()));
+        assert!(obj.as_ref().get_type().is_a(Self::get_type()));
 
         unsafe {
             let klass = (*(obj.as_ptr() as *const gobject_ffi::GTypeInstance)).g_class;

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -38,8 +38,7 @@ macro_rules! object_interface {
             });
 
             unsafe {
-                assert_ne!(TYPE, $crate::Type::INVALID);
-
+                assert!(TYPE.is_valid());
                 TYPE
             }
         }

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -232,7 +232,7 @@
 //! struct MyBoxed(String);
 //!
 //! pub fn main() {
-//!     assert_ne!(glib::Type::INVALID, MyBoxed::get_type());
+//!     assert!(MyBoxed::get_type().is_valid());
 //!
 //!     let b = MyBoxed(String::from("abc"));
 //!     let v = b.to_value();

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -232,7 +232,7 @@
 //! struct MyBoxed(String);
 //!
 //! pub fn main() {
-//!     assert_ne!(glib::Type::Invalid, MyBoxed::get_type());
+//!     assert_ne!(glib::Type::INVALID, MyBoxed::get_type());
 //!
 //!     let b = MyBoxed(String::from("abc"));
 //!     let v = b.to_value();

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -459,7 +459,7 @@ mod test {
         let type_ = SimpleObject::static_type();
         let obj = Object::with_type(type_, &[]).expect("Object::new failed");
 
-        assert!(obj.get_type().is_a(&DummyInterface::static_type()));
+        assert!(obj.get_type().is_a(DummyInterface::static_type()));
 
         assert_eq!(
             obj.get_property("constructed")
@@ -671,6 +671,6 @@ mod test {
             .emit_by_name("create-child-object", &[])
             .expect("Failed to emit")
             .expect("Failed to get value from emit");
-        assert!(value.type_().is_a(&ChildObject::static_type()));
+        assert!(value.type_().is_a(ChildObject::static_type()));
     }
 }

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -282,7 +282,7 @@ mod test {
                         super::Signal::builder(
                             "name-changed",
                             &[String::static_type().into()],
-                            crate::Type::Unit.into(),
+                            crate::Type::UNIT.into(),
                         )
                         .build(),
                         super::Signal::builder(

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -322,7 +322,7 @@ macro_rules! object_subclass {
             unsafe {
                 let data = Self::type_data();
                 let type_ = data.as_ref().get_type();
-                assert_ne!(type_, $crate::Type::INVALID);
+                assert!(type_.is_valid());
 
                 type_
             }
@@ -412,7 +412,7 @@ pub trait ObjectSubclass: Sized + 'static {
         unsafe {
             let data = Self::type_data();
             let type_ = data.as_ref().get_type();
-            assert_ne!(type_, Type::INVALID);
+            assert!(type_.is_valid());
 
             let offset = -data.as_ref().private_offset;
 
@@ -689,9 +689,5 @@ pub(crate) unsafe fn signal_chain_from_overridden(
         values.as_ptr() as *mut Value as *mut gobject_ffi::GValue,
         result.to_glib_none_mut().0,
     );
-    if result.type_() != Type::UNIT && result.type_() != Type::INVALID {
-        Some(result)
-    } else {
-        None
-    }
+    Some(result).filter(|r| r.type_().is_valid() && r.type_() != Type::UNIT)
 }

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -303,7 +303,7 @@ macro_rules! object_subclass {
     () => {
         fn type_data() -> std::ptr::NonNull<$crate::subclass::TypeData> {
             static mut DATA: $crate::subclass::TypeData = $crate::subclass::TypeData {
-                type_: $crate::Type::Invalid,
+                type_: $crate::Type::INVALID,
                 parent_class: std::ptr::null_mut(),
                 class_data: None,
                 private_offset: 0,
@@ -322,7 +322,7 @@ macro_rules! object_subclass {
             unsafe {
                 let data = Self::type_data();
                 let type_ = data.as_ref().get_type();
-                assert_ne!(type_, $crate::Type::Invalid);
+                assert_ne!(type_, $crate::Type::INVALID);
 
                 type_
             }
@@ -412,7 +412,7 @@ pub trait ObjectSubclass: Sized + 'static {
         unsafe {
             let data = Self::type_data();
             let type_ = data.as_ref().get_type();
-            assert_ne!(type_, Type::Invalid);
+            assert_ne!(type_, Type::INVALID);
 
             let offset = -data.as_ref().private_offset;
 
@@ -689,7 +689,7 @@ pub(crate) unsafe fn signal_chain_from_overridden(
         values.as_ptr() as *mut Value as *mut gobject_ffi::GValue,
         result.to_glib_none_mut().0,
     );
-    if result.type_() != Type::Unit && result.type_() != Type::Invalid {
+    if result.type_() != Type::UNIT && result.type_() != Type::INVALID {
         Some(result)
     } else {
         None

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -3,8 +3,8 @@
 //! Runtime type information.
 
 use crate::translate::{
-    from_glib, from_glib_none, FromGlib, FromGlibContainerAsVec, ToGlib, ToGlibContainerFromSlice,
-    ToGlibPtr, ToGlibPtrMut,
+    from_glib, FromGlib, FromGlibContainerAsVec, ToGlib, ToGlibContainerFromSlice, ToGlibPtr,
+    ToGlibPtrMut,
 };
 use crate::value::{FromValue, FromValueOptional, SetValue, Value};
 
@@ -84,10 +84,13 @@ impl Type {
     pub const OBJECT: Self = Self(gobject_ffi::G_TYPE_OBJECT);
 
     #[doc(alias = "g_type_name")]
-    pub fn name(self) -> String {
+    pub fn name<'a>(self) -> &'a str {
         match self.to_glib() {
-            gobject_ffi::G_TYPE_INVALID => "<invalid>".to_string(),
-            x => unsafe { from_glib_none(gobject_ffi::g_type_name(x)) },
+            gobject_ffi::G_TYPE_INVALID => "<invalid>",
+            x => unsafe {
+                let ptr = gobject_ffi::g_type_name(x);
+                std::ffi::CStr::from_ptr(ptr).to_str().unwrap()
+            },
         }
     }
 

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -107,12 +107,8 @@ impl Type {
     #[doc(alias = "g_type_parent")]
     pub fn parent(self) -> Option<Self> {
         unsafe {
-            let parent = from_glib(gobject_ffi::g_type_parent(self.to_glib()));
-            if parent == Self::INVALID {
-                None
-            } else {
-                Some(parent)
-            }
+            let parent: Self = from_glib(gobject_ffi::g_type_parent(self.to_glib()));
+            Some(parent).filter(|t| t.is_valid())
         }
     }
 
@@ -153,13 +149,16 @@ impl Type {
     #[doc(alias = "g_type_from_name")]
     pub fn from_name<'a, P: Into<&'a str>>(name: P) -> Option<Self> {
         unsafe {
-            let type_ = from_glib(gobject_ffi::g_type_from_name(name.into().to_glib_none().0));
-            if type_ == Self::INVALID {
-                None
-            } else {
-                Some(type_)
-            }
+            let type_: Self =
+                from_glib(gobject_ffi::g_type_from_name(name.into().to_glib_none().0));
+            Some(type_).filter(|t| t.is_valid())
         }
+    }
+
+    /// Checks that the type is not [`INVALID`](Self::INVALID)
+    #[inline]
+    pub fn is_valid(self) -> bool {
+        self != Self::INVALID
     }
 }
 
@@ -479,6 +478,7 @@ mod tests {
         assert_eq!(invalid.children(), vec![]);
         assert_eq!(invalid.interfaces(), vec![]);
         assert_eq!(invalid.interface_prerequisites(), vec![]);
+        assert!(!invalid.is_valid());
         dbg!(&invalid);
     }
 

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -84,7 +84,7 @@ impl Type {
     pub const OBJECT: Self = Self(gobject_ffi::G_TYPE_OBJECT);
 
     #[doc(alias = "g_type_name")]
-    pub fn name(&self) -> String {
+    pub fn name(self) -> String {
         match self.to_glib() {
             gobject_ffi::G_TYPE_INVALID => "<invalid>".to_string(),
             x => unsafe { from_glib_none(gobject_ffi::g_type_name(x)) },
@@ -92,7 +92,7 @@ impl Type {
     }
 
     #[doc(alias = "g_type_qname")]
-    pub fn qname(&self) -> crate::Quark {
+    pub fn qname(self) -> crate::Quark {
         match self.to_glib() {
             gobject_ffi::G_TYPE_INVALID => crate::Quark::from_string("<invalid>"),
             x => unsafe { from_glib(gobject_ffi::g_type_qname(x)) },
@@ -100,12 +100,12 @@ impl Type {
     }
 
     #[doc(alias = "g_type_is_a")]
-    pub fn is_a(&self, other: &Type) -> bool {
+    pub fn is_a(self, other: Self) -> bool {
         unsafe { from_glib(gobject_ffi::g_type_is_a(self.to_glib(), other.to_glib())) }
     }
 
     #[doc(alias = "g_type_parent")]
-    pub fn parent(&self) -> Option<Self> {
+    pub fn parent(self) -> Option<Self> {
         unsafe {
             let parent = from_glib(gobject_ffi::g_type_parent(self.to_glib()));
             if parent == Self::INVALID {
@@ -117,7 +117,7 @@ impl Type {
     }
 
     #[doc(alias = "g_type_children")]
-    pub fn children(&self) -> Vec<Self> {
+    pub fn children(self) -> Vec<Self> {
         unsafe {
             let mut n_children = 0u32;
             let children = gobject_ffi::g_type_children(self.to_glib(), &mut n_children);
@@ -127,7 +127,7 @@ impl Type {
     }
 
     #[doc(alias = "g_type_interfaces")]
-    pub fn interfaces(&self) -> Vec<Self> {
+    pub fn interfaces(self) -> Vec<Self> {
         unsafe {
             let mut n_interfaces = 0u32;
             let interfaces = gobject_ffi::g_type_interfaces(self.to_glib(), &mut n_interfaces);
@@ -137,9 +137,9 @@ impl Type {
     }
 
     #[doc(alias = "g_type_interface_prerequisites")]
-    pub fn interface_prerequisites(&self) -> Vec<Self> {
+    pub fn interface_prerequisites(self) -> Vec<Self> {
         match self {
-            t if !t.is_a(&Self::INTERFACE) => vec![],
+            t if !t.is_a(Self::INTERFACE) => vec![],
             _ => unsafe {
                 let mut n_prereqs = 0u32;
                 let prereqs =

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -225,7 +225,7 @@ impl Value {
     /// or is a sub-type of `T`.
     #[inline]
     pub fn is<'a, T: FromValueOptional<'a> + SetValue>(&self) -> bool {
-        self.type_().is_a(&T::static_type())
+        self.type_().is_a(T::static_type())
     }
 
     /// Returns the type of the value.

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -287,7 +287,7 @@ impl Drop for Value {
     fn drop(&mut self) {
         // Before GLib 2.48, unsetting a zeroed GValue would give critical warnings
         // https://bugzilla.gnome.org/show_bug.cgi?id=755766
-        if self.type_() != Type::Invalid {
+        if self.type_() != Type::INVALID {
             unsafe { gobject_ffi::g_value_unset(self.to_glib_none_mut().0) }
         }
     }
@@ -1138,11 +1138,11 @@ mod tests {
         assert_eq!(v.get_some::<i32>(), Ok(123));
         assert_eq!(
             v.get::<&str>(),
-            Err(GetError::new_type_mismatch(Type::I32, Type::String))
+            Err(GetError::new_type_mismatch(Type::I32, Type::STRING))
         );
         assert_eq!(
             v.get_some::<bool>(),
-            Err(GetError::new_type_mismatch(Type::I32, Type::Bool))
+            Err(GetError::new_type_mismatch(Type::I32, Type::BOOL))
         );
 
         let some_v = Some("test").to_value();
@@ -1150,7 +1150,7 @@ mod tests {
         assert_eq!(some_v.get::<&str>(), Ok(Some("test")));
         assert_eq!(
             some_v.get::<i32>(),
-            Err(GetError::new_type_mismatch(Type::String, Type::I32))
+            Err(GetError::new_type_mismatch(Type::STRING, Type::I32))
         );
 
         let none_str: Option<&str> = None;
@@ -1158,7 +1158,7 @@ mod tests {
         assert_eq!(none_v.get::<&str>(), Ok(None));
         assert_eq!(
             none_v.get::<i32>(),
-            Err(GetError::new_type_mismatch(Type::String, Type::I32))
+            Err(GetError::new_type_mismatch(Type::STRING, Type::I32))
         );
     }
 

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -287,7 +287,7 @@ impl Drop for Value {
     fn drop(&mut self) {
         // Before GLib 2.48, unsetting a zeroed GValue would give critical warnings
         // https://bugzilla.gnome.org/show_bug.cgi?id=755766
-        if self.type_() != Type::INVALID {
+        if self.type_().is_valid() {
             unsafe { gobject_ffi::g_value_unset(self.to_glib_none_mut().0) }
         }
     }

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -115,7 +115,7 @@ wrapper! {
 
 impl StaticType for Variant {
     fn static_type() -> Type {
-        Type::Variant
+        Type::VARIANT
     }
 }
 

--- a/gtk/src/subclass/container.rs
+++ b/gtk/src/subclass/container.rs
@@ -108,7 +108,7 @@ impl<T: ContainerImpl> ContainerImplExt for T {
             if let Some(f) = (*parent_class).child_type {
                 from_glib(f(container.unsafe_cast_ref::<Container>().to_glib_none().0))
             } else {
-                glib::Type::Unit
+                glib::Type::UNIT
             }
         }
     }


### PR DESCRIPTION
- Make `Type` leaner, replace enum with assoc consts.
- Pass `Type` by value, where possible
- Introduce `Type::is_valid` and use it
- Make `Type::name` return a `str`