### PR TITLE
 connect_unsafe: Refactor, then don't ignore the return_type for null objects 

### DIFF
--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1806,9 +1806,7 @@ impl<T: ObjectType> ObjectExt for T {
 
                 match opt_obj {
                     Some(obj) => {
-                        if obj.get_type().is_a(return_type) {
-                            ret.0.g_type = return_type.to_glib();
-                        } else {
+                        if !obj.get_type().is_a(return_type) {
                             panic!(
                                 "Signal '{}' of type '{}' required return value of type '{}' but got '{}' (actual '{}')",
                                 signal_name,
@@ -1819,12 +1817,10 @@ impl<T: ObjectType> ObjectExt for T {
                             );
                         }
                     }
-                    None => {
-                        // If the value is None then the type is compatible too
-                        ret.0.g_type = return_type.to_glib();
-                    }
+                    None => {} // If the value is None then the type is compatible too
                 }
 
+                ret.0.g_type = return_type.to_glib();
                 Some(ret)
             })
         };

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1804,20 +1804,16 @@ impl<T: ObjectType> ObjectExt for T {
                     );
                 });
 
-                match opt_obj {
-                    Some(obj) => {
-                        if !obj.get_type().is_a(return_type) {
-                            panic!(
-                                "Signal '{}' of type '{}' required return value of type '{}' but got '{}' (actual '{}')",
-                                signal_name,
-                                type_,
-                                return_type,
-                                ret.type_(),
-                                obj.get_type()
-                            );
-                        }
-                    }
-                    None => {} // If the value is None then the type is compatible too
+                let actual_type = opt_obj.map_or_else(|| ret.type_(), |obj| obj.get_type());
+                if !actual_type.is_a(return_type) {
+                    panic!(
+                        "Signal '{}' of type '{}' required return value of type '{}' but got '{}' (actual '{}')",
+                        signal_name,
+                        type_,
+                        return_type,
+                        ret.type_(),
+                        actual_type
+                    );
                 }
 
                 ret.0.g_type = return_type.to_glib();

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1794,29 +1794,7 @@ impl<T: ObjectType> ObjectExt for T {
                 // actual typed of the contained object is compatible and if so create
                 // a properly typed Value. This can happen if the type field in the
                 // Value is set to a more generic type than the contained value
-                if ret.type_().is_a(Object::static_type()) {
-                    match ret.get::<Object>() {
-                        Ok(Some(obj)) => {
-                            if obj.get_type().is_a(return_type) {
-                                ret.0.g_type = return_type.to_glib();
-                            } else {
-                                panic!(
-                                    "Signal '{}' of type '{}' required return value of type '{}' but got '{}' (actual '{}')",
-                                    signal_name,
-                                    type_,
-                                    return_type,
-                                    ret.type_(),
-                                    obj.get_type()
-                                );
-                            }
-                        }
-                        Ok(None) => {
-                            // If the value is None then the type is compatible too
-                            ret.0.g_type = return_type.to_glib();
-                        }
-                        Err(_) => unreachable!("ret type conformity already checked"),
-                    }
-                } else {
+                if !ret.type_().is_a(Object::static_type()) {
                     panic!(
                         "Signal '{}' of type '{}' required return value of type '{}' but got '{}'",
                         signal_name,
@@ -1825,6 +1803,29 @@ impl<T: ObjectType> ObjectExt for T {
                         ret.type_()
                     );
                 }
+
+                match ret.get::<Object>() {
+                    Ok(Some(obj)) => {
+                        if obj.get_type().is_a(return_type) {
+                            ret.0.g_type = return_type.to_glib();
+                        } else {
+                            panic!(
+                                "Signal '{}' of type '{}' required return value of type '{}' but got '{}' (actual '{}')",
+                                signal_name,
+                                type_,
+                                return_type,
+                                ret.type_(),
+                                obj.get_type()
+                            );
+                        }
+                    }
+                    Ok(None) => {
+                        // If the value is None then the type is compatible too
+                        ret.0.g_type = return_type.to_glib();
+                    }
+                    Err(_) => unreachable!("ret type conformity already checked"),
+                }
+
                 Some(ret)
             })
         };

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1794,7 +1794,7 @@ impl<T: ObjectType> ObjectExt for T {
                 // actual typed of the contained object is compatible and if so create
                 // a properly typed Value. This can happen if the type field in the
                 // Value is set to a more generic type than the contained value
-                if !ret.type_().is_a(Object::static_type()) {
+                let opt_obj = ret.get::<Object>().unwrap_or_else(|_| {
                     panic!(
                         "Signal '{}' of type '{}' required return value of type '{}' but got '{}'",
                         signal_name,
@@ -1802,10 +1802,10 @@ impl<T: ObjectType> ObjectExt for T {
                         return_type,
                         ret.type_()
                     );
-                }
+                });
 
-                match ret.get::<Object>() {
-                    Ok(Some(obj)) => {
+                match opt_obj {
+                    Some(obj) => {
                         if obj.get_type().is_a(return_type) {
                             ret.0.g_type = return_type.to_glib();
                         } else {
@@ -1819,11 +1819,10 @@ impl<T: ObjectType> ObjectExt for T {
                             );
                         }
                     }
-                    Ok(None) => {
+                    None => {
                         // If the value is None then the type is compatible too
                         ret.0.g_type = return_type.to_glib();
                     }
-                    Err(_) => unreachable!("ret type conformity already checked"),
                 }
 
                 Some(ret)

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1786,11 +1786,15 @@ impl<T: ObjectType> ObjectExt for T {
                     return_type.to_glib(),
                 ));
 
+                if valid_type {
+                    return Some(ret);
+                }
+
                 // If it's not directly a valid type but an object type, we check if the
                 // actual typed of the contained object is compatible and if so create
                 // a properly typed Value. This can happen if the type field in the
                 // Value is set to a more generic type than the contained value
-                if !valid_type && ret.type_().is_a(Object::static_type()) {
+                if ret.type_().is_a(Object::static_type()) {
                     match ret.get::<Object>() {
                         Ok(Some(obj)) => {
                             if obj.get_type().is_a(return_type) {
@@ -1812,7 +1816,7 @@ impl<T: ObjectType> ObjectExt for T {
                         }
                         Err(_) => unreachable!("ret type conformity already checked"),
                     }
-                } else if !valid_type {
+                } else {
                     panic!(
                         "Signal '{}' of type '{}' required return value of type '{}' but got '{}'",
                         signal_name,


### PR DESCRIPTION
This series contains a hopefully easy-to-follow series of refactorings, followed by a commit fixing an actual bug:

When the callback returned an `Object`-typed `Value` containing a `None`, the code accepted it and transmuted the `Value` into the `return_type`, even if that `Type` wasn't an `Object`, with undefined behavior.

If the `Value` doesn't contain `Some` `Object`, check the `Value`'s `Type` against the `return_type` instead.