### PR TITLE
glib: `#[object_subclass]` proc macro.

### DIFF
--- a/examples/src/bin/basic_subclass.rs
+++ b/examples/src/bin/basic_subclass.rs
@@ -9,7 +9,6 @@ use gio::ApplicationFlags;
 use gtk::{gio, glib};
 
 use glib::clone;
-use glib::subclass;
 
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
@@ -30,28 +29,17 @@ mod imp_win {
     // This is the private part of our `SimpleWindow` object.
     // Its where state and widgets are stored when they don't
     // need to be publicly accesible.
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     pub struct SimpleWindow {
         widgets: OnceCell<WindowWidgets>,
         counter: Cell<u64>,
     }
 
+    #[glib::object_subclass]
     impl ObjectSubclass for SimpleWindow {
         const NAME: &'static str = "SimpleWindow";
         type Type = super::SimpleWindow;
         type ParentType = gtk::ApplicationWindow;
-        type Interfaces = ();
-        type Instance = subclass::simple::InstanceStruct<Self>;
-        type Class = subclass::simple::ClassStruct<Self>;
-
-        glib::object_subclass!();
-
-        fn new() -> Self {
-            Self {
-                widgets: OnceCell::new(),
-                counter: Cell::new(0),
-            }
-        }
     }
 
     impl ObjectImpl for SimpleWindow {
@@ -120,26 +108,16 @@ impl SimpleWindow {
 mod imp_app {
     use super::*;
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     pub struct SimpleApplication {
         window: OnceCell<SimpleWindow>,
     }
 
+    #[glib::object_subclass]
     impl ObjectSubclass for SimpleApplication {
         const NAME: &'static str = "SimpleApplication";
         type Type = super::SimpleApplication;
         type ParentType = gtk::Application;
-        type Interfaces = ();
-        type Instance = subclass::simple::InstanceStruct<Self>;
-        type Class = subclass::simple::ClassStruct<Self>;
-
-        glib::object_subclass!();
-
-        fn new() -> Self {
-            Self {
-                window: OnceCell::new(),
-            }
-        }
     }
 
     impl ObjectImpl for SimpleApplication {}

--- a/examples/src/bin/composite_template.rs
+++ b/examples/src/bin/composite_template.rs
@@ -8,11 +8,10 @@ use gtk::{prelude::*, CompositeTemplate};
 
 mod imp {
     use super::*;
-    use glib::subclass;
     use gtk::subclass::prelude::*;
 
     /// The private struct, which can hold widgets and other data.
-    #[derive(Debug, CompositeTemplate)]
+    #[derive(Debug, Default, CompositeTemplate)]
     #[template(file = "composite_template.ui")]
     pub struct ExApplicationWindow {
         // The #[template_child] attribute tells the CompositeTemplate macro
@@ -27,23 +26,11 @@ mod imp {
         pub subtitle: TemplateChild<gtk::Label>,
     }
 
+    #[glib::object_subclass]
     impl ObjectSubclass for ExApplicationWindow {
         const NAME: &'static str = "ExApplicationWindow";
         type Type = super::ExApplicationWindow;
         type ParentType = gtk::ApplicationWindow;
-        type Interfaces = ();
-        type Instance = subclass::simple::InstanceStruct<Self>;
-        type Class = subclass::simple::ClassStruct<Self>;
-
-        glib::object_subclass!();
-
-        fn new() -> Self {
-            Self {
-                headerbar: TemplateChild::default(),
-                label: TemplateChild::default(),
-                subtitle: TemplateChild::default(),
-            }
-        }
 
         // Within class_init() you must set the template.
         // The CompositeTemplate derive macro provides a convenience function

--- a/examples/src/bin/gio_task.rs
+++ b/examples/src/bin/gio_task.rs
@@ -5,7 +5,6 @@
 //! This can be useful, for example, when porting to Rust some existing C code exposing such an API.
 
 use futures_channel::oneshot;
-use gtk::glib::subclass;
 use gtk::glib::subclass::prelude::*;
 use gtk::glib::translate::*;
 use gtk::prelude::AsyncResultExt;
@@ -19,24 +18,16 @@ mod imp {
 
     // FileSize is a simple object that will just contain the read file size.
     // Initially the optional size field will be initialized to None.
+    #[derive(Default)]
     pub struct FileSize {
         pub size: std::cell::RefCell<Option<i64>>,
     }
 
+    #[glib::object_subclass]
     impl ObjectSubclass for FileSize {
         const NAME: &'static str = "FileSize";
         type ParentType = glib::Object;
-        type Instance = subclass::simple::InstanceStruct<Self>;
-        type Interfaces = ();
-        type Class = subclass::simple::ClassStruct<Self>;
         type Type = super::FileSize;
-        glib::object_subclass!();
-
-        fn new() -> Self {
-            Self {
-                size: std::cell::RefCell::new(None),
-            }
-        }
     }
 
     impl ObjectImpl for FileSize {}

--- a/examples/src/bin/listbox_model.rs
+++ b/examples/src/bin/listbox_model.rs
@@ -26,7 +26,7 @@ mod model {
         use glib::subclass;
         use glib::subclass::prelude::*;
         use std::cell::RefCell;
-        #[derive(Debug)]
+        #[derive(Debug, Default)]
         pub struct Model(pub RefCell<Vec<RowData>>);
 
         // Basic declaration of our type for the GObject type system
@@ -35,15 +35,6 @@ mod model {
             type Type = super::Model;
             type ParentType = glib::Object;
             type Interfaces = (gio::ListModel,);
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Class = subclass::simple::ClassStruct<Self>;
-
-            glib::object_subclass!();
-
-            // Called once at the very beginning of instantiation
-            fn new() -> Self {
-                Self(RefCell::new(Vec::new()))
-            }
         }
 
         impl ObjectImpl for Model {}
@@ -296,6 +287,7 @@ mod row_data {
 
         // The actual data structure that stores our values. This is not accessible
         // directly from the outside.
+        #[derive(Default)]
         pub struct RowData {
             name: RefCell<Option<String>>,
             count: RefCell<u32>,
@@ -306,20 +298,6 @@ mod row_data {
             const NAME: &'static str = "RowData";
             type Type = super::RowData;
             type ParentType = glib::Object;
-            type Interfaces = ();
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Class = subclass::simple::ClassStruct<Self>;
-
-            glib::object_subclass!();
-
-            // Called once at the very beginning of instantiation of each instance and
-            // creates the data structure that contains all our state
-            fn new() -> Self {
-                Self {
-                    name: RefCell::new(None),
-                    count: RefCell::new(0),
-                }
-            }
         }
 
         // The ObjectImpl trait provides the setters/getters for GObject properties.

--- a/gio/src/read_input_stream.rs
+++ b/gio/src/read_input_stream.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::subclass::prelude::*;
 use crate::InputStream;
-use glib::subclass;
 
 use std::any::Any;
 use std::io::{Read, Seek};
@@ -17,25 +16,17 @@ mod imp {
         ReadSeek(AnyReader),
     }
 
+    #[derive(Default)]
     pub struct ReadInputStream {
         pub(super) read: RefCell<Option<Reader>>,
     }
 
+    #[glib::object_subclass]
     impl ObjectSubclass for ReadInputStream {
         const NAME: &'static str = "ReadInputStream";
         type Type = super::ReadInputStream;
         type ParentType = InputStream;
         type Interfaces = (crate::Seekable,);
-        type Instance = subclass::simple::InstanceStruct<Self>;
-        type Class = subclass::simple::ClassStruct<Self>;
-
-        glib::object_subclass!();
-
-        fn new() -> Self {
-            Self {
-                read: RefCell::new(None),
-            }
-        }
     }
 
     impl ObjectImpl for ReadInputStream {}

--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -480,28 +480,20 @@ unsafe extern "C" fn application_handle_local_options<T: ApplicationImpl>(
 mod tests {
     use super::*;
     use crate::prelude::*;
-    use glib::subclass;
 
     const EXIT_STATUS: i32 = 20;
 
     mod imp {
         use super::*;
 
+        #[derive(Default)]
         pub struct SimpleApplication;
 
+        #[glib::object_subclass]
         impl ObjectSubclass for SimpleApplication {
             const NAME: &'static str = "SimpleApplication";
             type Type = super::SimpleApplication;
             type ParentType = Application;
-            type Interfaces = ();
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Class = subclass::simple::ClassStruct<Self>;
-
-            glib::object_subclass!();
-
-            fn new() -> Self {
-                Self
-            }
         }
 
         impl ObjectImpl for SimpleApplication {}

--- a/gio/src/subclass/input_stream.rs
+++ b/gio/src/subclass/input_stream.rs
@@ -255,31 +255,22 @@ mod tests {
     use super::*;
     use crate::prelude::*;
     use crate::subclass::prelude::*;
-    use glib::subclass;
     use std::cell::RefCell;
 
     mod imp {
         use super::*;
 
+        #[derive(Default)]
         pub struct SimpleInputStream {
             pub pos: RefCell<usize>,
         }
 
+        #[glib::object_subclass]
         impl ObjectSubclass for SimpleInputStream {
             const NAME: &'static str = "SimpleInputStream";
             type Type = super::SimpleInputStream;
             type ParentType = InputStream;
             type Interfaces = (crate::Seekable,);
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Class = subclass::simple::ClassStruct<Self>;
-
-            glib::object_subclass!();
-
-            fn new() -> Self {
-                Self {
-                    pos: RefCell::new(0),
-                }
-            }
         }
 
         impl ObjectImpl for SimpleInputStream {}

--- a/gio/src/subclass/output_stream.rs
+++ b/gio/src/subclass/output_stream.rs
@@ -317,31 +317,21 @@ unsafe extern "C" fn stream_splice<T: OutputStreamImpl>(
 mod tests {
     use super::*;
     use crate::prelude::*;
-    use glib::subclass;
     use std::cell::RefCell;
 
     mod imp {
         use super::*;
 
+        #[derive(Default)]
         pub struct SimpleOutputStream {
             pub sum: RefCell<usize>,
         }
 
+        #[glib::object_subclass]
         impl ObjectSubclass for SimpleOutputStream {
             const NAME: &'static str = "SimpleOutputStream";
             type Type = super::SimpleOutputStream;
             type ParentType = OutputStream;
-            type Interfaces = ();
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Class = subclass::simple::ClassStruct<Self>;
-
-            glib::object_subclass!();
-
-            fn new() -> Self {
-                Self {
-                    sum: RefCell::new(0),
-                }
-            }
         }
 
         impl ObjectImpl for SimpleOutputStream {}

--- a/gio/src/task.rs
+++ b/gio/src/task.rs
@@ -119,20 +119,16 @@ mod test {
 
     #[test]
     fn test_object_async_result() {
-        use glib::subclass;
         use glib::subclass::prelude::*;
         pub struct MySimpleObjectPrivate {
             pub size: std::cell::RefCell<Option<i64>>,
         }
 
+        #[glib::object_subclass]
         impl ObjectSubclass for MySimpleObjectPrivate {
             const NAME: &'static str = "MySimpleObjectPrivate";
             type ParentType = glib::Object;
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Interfaces = ();
-            type Class = subclass::simple::ClassStruct<Self>;
             type Type = MySimpleObject;
-            glib::object_subclass!();
 
             fn new() -> Self {
                 Self {

--- a/gio/src/write_output_stream.rs
+++ b/gio/src/write_output_stream.rs
@@ -3,7 +3,6 @@
 use crate::prelude::*;
 use crate::subclass::prelude::*;
 use crate::OutputStream;
-use glib::subclass;
 
 use std::any::Any;
 use std::io::{Seek, Write};
@@ -19,25 +18,17 @@ mod imp {
         WriteSeek(AnyWriter),
     }
 
+    #[derive(Default)]
     pub struct WriteOutputStream {
         pub(super) write: RefCell<Option<Writer>>,
     }
 
+    #[glib::object_subclass]
     impl ObjectSubclass for WriteOutputStream {
         const NAME: &'static str = "WriteOutputStream";
         type Type = super::WriteOutputStream;
         type ParentType = OutputStream;
         type Interfaces = (crate::Seekable,);
-        type Instance = subclass::simple::InstanceStruct<Self>;
-        type Class = subclass::simple::ClassStruct<Self>;
-
-        glib::object_subclass!();
-
-        fn new() -> Self {
-            Self {
-                write: RefCell::new(None),
-            }
-        }
     }
 
     impl ObjectImpl for WriteOutputStream {}

--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -16,7 +16,7 @@ heck = "0.3"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = { version = "1.0", features = ["full"] }
 proc-macro-crate = "0.1"
 
 [lib]

--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -1,0 +1,94 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use proc_macro2::TokenStream;
+use proc_macro_error::abort_call_site;
+use quote::quote;
+
+pub const WRONG_PLACE_MSG: &str =
+    "This macro should be used on `impl` block for `glib::ObjectSubclass` trait";
+
+pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
+    let mut has_new = false;
+    let mut has_interfaces = false;
+    let mut has_instance = false;
+    let mut has_class = false;
+    for item in &input.items {
+        match item {
+            syn::ImplItem::Method(method) => {
+                let name = method.sig.ident.to_string();
+                if name == "new" || name == "with_class" {
+                    has_new = true;
+                }
+            }
+            syn::ImplItem::Type(type_) => {
+                let name = type_.ident.to_string();
+                if name == "Interfaces" {
+                    has_interfaces = true;
+                } else if name == "Instance" {
+                    has_instance = true;
+                } else if name == "Class" {
+                    has_class = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let syn::ItemImpl {
+        attrs,
+        generics,
+        trait_,
+        self_ty,
+        items,
+        ..
+    } = &input;
+
+    let interfaces_opt = if has_interfaces {
+        None
+    } else {
+        Some(quote!(
+            type Interfaces = ();
+        ))
+    };
+
+    let new_opt = if has_new {
+        None
+    } else {
+        Some(quote! {
+            fn new() -> Self {
+                std::default::Default::default()
+            }
+        })
+    };
+
+    let crate_ident = crate::utils::crate_ident_new();
+
+    let class_opt = if has_class {
+        None
+    } else {
+        Some(quote!(type Class = #crate_ident::subclass::simple::ClassStruct<Self>;))
+    };
+
+    let instance_opt = if has_instance {
+        None
+    } else {
+        Some(quote!(type Instance = #crate_ident::subclass::simple::InstanceStruct<Self>;))
+    };
+
+    let trait_path = match &trait_ {
+        Some(path) => &path.1,
+        None => abort_call_site!(WRONG_PLACE_MSG),
+    };
+
+    quote! {
+        #(#attrs)*
+        impl#generics #trait_path for #self_ty {
+            #interfaces_opt
+            #class_opt
+            #instance_opt
+            #new_opt
+            #crate_ident::object_subclass_internal!();
+            #(#items)*
+        }
+    }
+}

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -83,7 +83,7 @@ pub use gobject_ffi;
 #[doc(hidden)]
 pub use bitflags;
 
-pub use glib_macros::{clone, gflags, Downgrade, GBoxed, GEnum};
+pub use glib_macros::{clone, gflags, object_subclass, Downgrade, GBoxed, GEnum};
 
 pub use self::byte_array::ByteArray;
 pub use self::bytes::Bytes;

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -68,6 +68,7 @@
 //!     // ObjectSubclass is the trait that defines the new type and
 //!     // contains all information needed by the GObject type system,
 //!     // including the new type's name, parent type, etc.
+//!     #[glib::object_subclass]
 //!     impl ObjectSubclass for SimpleObject {
 //!         // This type name must be unique per process.
 //!         const NAME: &'static str = "SimpleObject";
@@ -78,16 +79,6 @@
 //!
 //!         // Interfaces this type implements
 //!         type Interfaces = ();
-//!
-//!         // The C/FFI instance and class structs. The simple ones
-//!         // are enough in most cases and more is only needed to
-//!         // expose public instance fields to C APIs or to provide
-//!         // new virtual methods for subclasses of this type.
-//!         type Instance = subclass::simple::InstanceStruct<Self>;
-//!         type Class = subclass::simple::ClassStruct<Self>;
-//!
-//!         // This macro defines some boilerplate.
-//!         glib::object_subclass!();
 //!
 //!         // Called every time a new instance is created. This should return
 //!         // a new instance of our type with its basic values.

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -223,6 +223,7 @@ mod test {
     use super::super::super::subclass;
     use super::super::super::value::{ToValue, Value};
     use super::*;
+    use crate as glib;
     use crate::{StaticType, Type};
 
     use std::cell::RefCell;
@@ -231,47 +232,31 @@ mod test {
         use super::*;
 
         // A dummy `Object` to test setting an `Object` property and returning an `Object` in signals
+        #[derive(Default)]
         pub struct ChildObject;
+
+        #[glib::object_subclass]
         impl ObjectSubclass for ChildObject {
             const NAME: &'static str = "ChildObject";
             type Type = super::ChildObject;
             type ParentType = Object;
-            type Interfaces = ();
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Class = subclass::simple::ClassStruct<Self>;
-
-            object_subclass!();
-
-            fn new() -> Self {
-                ChildObject
-            }
         }
 
         impl ObjectImpl for ChildObject {}
 
+        #[derive(Default)]
         pub struct SimpleObject {
             name: RefCell<Option<String>>,
             construct_name: RefCell<Option<String>>,
             constructed: RefCell<bool>,
         }
 
+        #[glib::object_subclass]
         impl ObjectSubclass for SimpleObject {
             const NAME: &'static str = "SimpleObject";
             type Type = super::SimpleObject;
             type ParentType = Object;
             type Interfaces = (DummyInterface,);
-            type Instance = subclass::simple::InstanceStruct<Self>;
-            type Class = subclass::simple::ClassStruct<Self>;
-
-            object_subclass!();
-
-            fn new() -> Self {
-                Self {
-                    name: RefCell::new(None),
-                    construct_name: RefCell::new(None),
-                    constructed: RefCell::new(false),
-                }
-            }
         }
 
         impl ObjectImpl for SimpleObject {

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -296,10 +296,8 @@ impl TypeData {
 }
 
 #[macro_export]
-/// Macro for boilerplate of [`ObjectSubclass`] implementations.
-///
-/// [`ObjectSubclass`]: subclass/types/trait.ObjectSubclass.html
-macro_rules! object_subclass {
+#[doc(hidden)]
+macro_rules! object_subclass_internal {
     () => {
         fn type_data() -> std::ptr::NonNull<$crate::subclass::TypeData> {
             static mut DATA: $crate::subclass::TypeData = $crate::subclass::TypeData {

--- a/gtk3-macros/src/lib.rs
+++ b/gtk3-macros/src/lib.rs
@@ -25,7 +25,7 @@ use syn::{parse_macro_input, DeriveInput};
 /// use gtk::prelude::*;
 /// use gtk::CompositeTemplate;
 ///
-/// #[derive(Debug, CompositeTemplate)]
+/// #[derive(Debug, Default, CompositeTemplate)]
 /// #[template(file = "composite_template.ui")]
 /// struct MyWidget {
 ///     #[template_child]
@@ -39,20 +39,11 @@ use syn::{parse_macro_input, DeriveInput};
 ///
 ///
 /// ```compile_fail
+/// #[glib::object_subclass]
 /// impl ObjectSubclass for MyWidget {
 ///        const NAME: &'static str = "MyWidget";
 ///        type Type = super::MyWidget;
 ///        type ParentType = gtk::Widget;
-///        type Instance = subclass::simple::InstanceStruct<Self>;
-///        type Class = subclass::simple::ClassStruct<Self>;
-///
-///        glib::object_subclass!();
-///
-///        fn new() -> Self {
-///            Self {
-///                label: TemplateChild::default(),
-///            }
-///        }
 ///
 ///        fn class_init(klass: &mut Self::Class) {
 ///            Self::bind_template(klass);


### PR DESCRIPTION
Proposed in https://github.com/gtk-rs/gtk-rs/issues/322.

This replaces `object_subclass!` while also magically adding support for associated type defaults, and making `new()` call `Default::default()`.

A draft because I still need to update the other crates to use this, test it a bit more, and perhaps tweak the errors it produces and the documentation.

A proc macro like this here could be useful for other things. For instance, to address https://github.com/gtk-rs/gtk-rs/issues/215 by splitting `type_data` and `get_type` into a separate `unsafe trait`. That is not implemented here.