### PR TITLE
CI: add a docker image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,23 @@
+name: github packages
+
+on:
+  push:
+    paths:
+      - "Dockerfile"
+    branches:
+      - "master"
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          push: true
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          repository: ${{ github.repository }}/gtk
+          tags: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.10
+
+RUN apt update -y
+RUN apt install -y \
+    libgtk-3-dev \
+    libglib2.0-dev \
+    libgraphene-1.0-dev \
+    git \
+    xvfb \
+    curl \
+    libcairo-gobject2 \
+    libcairo2-dev


### PR DESCRIPTION
This adds a `Dockerfile` and a CI job that builds the image and publish it on Github Packages containers registry. A future PR will migrate the CI to use it as we need to merge it first to get the image built & published.

