### PR TITLE
object: Return a pointer from get_qdata, not a reference

### DIFF
--- a/gio/src/subclass/io_stream.rs
+++ b/gio/src/subclass/io_stream.rs
@@ -122,7 +122,11 @@ unsafe extern "C" fn stream_get_input_stream<T: IOStreamImpl>(
     // b) that the same stream is returned every time. This is a requirement by the
     // IO stream API.
     if let Some(old_stream) = wrap.get_qdata::<InputStream>(*INPUT_STREAM_QUARK) {
-        assert_eq!(old_stream, &ret, "Did not return same input stream again");
+        assert_eq!(
+            old_stream.as_ref(),
+            &ret,
+            "Did not return same input stream again"
+        );
     }
     wrap.set_qdata(*INPUT_STREAM_QUARK, ret.clone());
     ret.to_glib_none().0
@@ -141,7 +145,11 @@ unsafe extern "C" fn stream_get_output_stream<T: IOStreamImpl>(
     // b) that the same stream is returned every time. This is a requirement by the
     // IO stream API.
     if let Some(old_stream) = wrap.get_qdata::<OutputStream>(*OUTPUT_STREAM_QUARK) {
-        assert_eq!(old_stream, &ret, "Did not return same output stream again");
+        assert_eq!(
+            old_stream.as_ref(),
+            &ret,
+            "Did not return same output stream again"
+        );
     }
     wrap.set_qdata(*OUTPUT_STREAM_QUARK, ret.clone());
     ret.to_glib_none().0

--- a/gio/src/subclass/list_model.rs
+++ b/gio/src/subclass/list_model.rs
@@ -46,7 +46,8 @@ where
     match wrap.get_qdata(*LIST_ITEM_TYPE_QUARK) {
         Some(old_type) => {
             assert_eq!(
-                type_, *old_type,
+                type_,
+                *old_type.as_ref(),
                 "ListModel's get_item_type cannot be changed"
             );
         }


### PR DESCRIPTION
A returned reference can become dangling by a concurrent `set_data` or
`steal_data`. Return a pointer instead.