### PR TITLE
glib: Distinguish between classes and interfaces at the type level

### DIFF
--- a/gio/src/subclass/action_group.rs
+++ b/gio/src/subclass/action_group.rs
@@ -301,7 +301,7 @@ pub trait ActionGroupImpl: ObjectImpl {
 }
 
 unsafe impl<T: ActionGroupImpl> IsImplementable<T> for ActionGroup {
-    fn interface_init(iface: &mut glib::Class<Self>) {
+    fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
         iface.action_added = Some(action_group_action_added::<T>);

--- a/gio/src/subclass/action_map.rs
+++ b/gio/src/subclass/action_map.rs
@@ -17,7 +17,7 @@ unsafe impl<T: ActionMapImpl> IsImplementable<T> for ActionMap
 where
     <T as ObjectSubclass>::Type: IsA<glib::Object>,
 {
-    fn interface_init(iface: &mut glib::Class<Self>) {
+    fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
         iface.lookup_action = Some(action_map_lookup_action::<T>);

--- a/gio/src/subclass/list_model.rs
+++ b/gio/src/subclass/list_model.rs
@@ -16,7 +16,7 @@ unsafe impl<T: ListModelImpl> IsImplementable<T> for ListModel
 where
     <T as ObjectSubclass>::Type: IsA<glib::Object>,
 {
-    fn interface_init(iface: &mut glib::Class<Self>) {
+    fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
         iface.get_item_type = Some(list_model_get_item_type::<T>);

--- a/gio/src/subclass/seekable.rs
+++ b/gio/src/subclass/seekable.rs
@@ -32,7 +32,7 @@ pub trait SeekableImpl: ObjectImpl + Send {
 }
 
 unsafe impl<T: SeekableImpl> IsImplementable<T> for Seekable {
-    fn interface_init(iface: &mut glib::Class<Self>) {
+    fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
         iface.tell = Some(seekable_tell::<T>);

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -91,7 +91,8 @@ pub use self::closure::Closure;
 pub use self::error::{BoolError, Error};
 pub use self::file_error::FileError;
 pub use self::object::{
-    Cast, Class, InitiallyUnowned, IsA, Object, ObjectExt, ObjectType, SendWeakRef, WeakRef,
+    Cast, Class, InitiallyUnowned, Interface, IsA, Object, ObjectExt, ObjectType, SendWeakRef,
+    WeakRef,
 };
 pub use self::signal::{
     signal_handler_block, signal_handler_disconnect, signal_handler_unblock,

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -426,7 +426,7 @@ mod test {
     }
 
     unsafe impl<T: ObjectSubclass> IsImplementable<T> for Dummy {
-        fn interface_init(_iface: &mut crate::Class<Dummy>) {}
+        fn interface_init(_iface: &mut crate::Interface<Dummy>) {}
         fn instance_init(_instance: &mut super::super::InitializingObject<T>) {}
     }
 

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -113,7 +113,7 @@ pub unsafe trait ClassStruct: Sized + 'static {
 }
 
 /// Trait for subclassable class structs.
-pub unsafe trait IsSubclassable<T: ObjectSubclass>: ObjectType {
+pub unsafe trait IsSubclassable<T: ObjectSubclass>: crate::object::IsClass {
     /// Override the virtual methods of this class for the given subclass and do other class
     /// initialization.
     ///
@@ -129,12 +129,12 @@ pub unsafe trait IsSubclassable<T: ObjectSubclass>: ObjectType {
 }
 
 /// Trait for implementable interfaces.
-pub unsafe trait IsImplementable<T: ObjectSubclass>: ObjectType {
+pub unsafe trait IsImplementable<T: ObjectSubclass>: crate::object::IsInterface {
     /// Override the virtual methods of this interface for the given subclass and do other
     /// interface initialization.
     ///
     /// This is automatically called during type initialization.
-    fn interface_init(iface: &mut crate::Class<Self>);
+    fn interface_init(iface: &mut crate::Interface<Self>);
 
     /// Instance specific initialization.
     ///
@@ -146,7 +146,7 @@ unsafe extern "C" fn interface_init<T: ObjectSubclass, A: IsImplementable<T>>(
     iface: ffi::gpointer,
     _iface_data: ffi::gpointer,
 ) {
-    let iface = &mut *(iface as *mut crate::Class<A>);
+    let iface = &mut *(iface as *mut crate::Interface<A>);
     A::interface_init(iface);
 }
 


### PR DESCRIPTION
Without this it was possible to cast from a Class<T> to a Class<U> where
U is an interface type. This doesn't work as interface structs are to be
retrieved differently than just casting and would cause memory unsafety
issues.

Fixes https://github.com/gtk-rs/gtk-rs/issues/348