### PR TITLE
Make `drag-motion` and `drag-drop` signals return `bool` instead of `Inhibit`

### DIFF
--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -2706,13 +2706,7 @@ manual_traits = ["WidgetExtManual"]
         name = "data"
         transformation = "borrow"
     [[object.signal]]
-    name = "drag-drop"
-    inhibit = true
-    [[object.signal]]
     name = "drag-failed"
-    inhibit = true
-    [[object.signal]]
-    name = "drag-motion"
     inhibit = true
     [[object.signal]]
     name = "draw"

--- a/gtk/src/auto/widget.rs
+++ b/gtk/src/auto/widget.rs
@@ -909,9 +909,7 @@ pub trait WidgetExt: 'static {
         f: F,
     ) -> SignalHandlerId;
 
-    fn connect_drag_drop<
-        F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> glib::signal::Inhibit + 'static,
-    >(
+    fn connect_drag_drop<F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> bool + 'static>(
         &self,
         f: F,
     ) -> SignalHandlerId;
@@ -930,9 +928,7 @@ pub trait WidgetExt: 'static {
         f: F,
     ) -> SignalHandlerId;
 
-    fn connect_drag_motion<
-        F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> glib::signal::Inhibit + 'static,
-    >(
+    fn connect_drag_motion<F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> bool + 'static>(
         &self,
         f: F,
     ) -> SignalHandlerId;
@@ -3668,15 +3664,13 @@ impl<O: IsA<Widget>> WidgetExt for O {
         }
     }
 
-    fn connect_drag_drop<
-        F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> glib::signal::Inhibit + 'static,
-    >(
+    fn connect_drag_drop<F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> bool + 'static>(
         &self,
         f: F,
     ) -> SignalHandlerId {
         unsafe extern "C" fn drag_drop_trampoline<
             P,
-            F: Fn(&P, &gdk::DragContext, i32, i32, u32) -> glib::signal::Inhibit + 'static,
+            F: Fn(&P, &gdk::DragContext, i32, i32, u32) -> bool + 'static,
         >(
             this: *mut ffi::GtkWidget,
             context: *mut gdk::ffi::GdkDragContext,
@@ -3809,15 +3803,13 @@ impl<O: IsA<Widget>> WidgetExt for O {
         }
     }
 
-    fn connect_drag_motion<
-        F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> glib::signal::Inhibit + 'static,
-    >(
+    fn connect_drag_motion<F: Fn(&Self, &gdk::DragContext, i32, i32, u32) -> bool + 'static>(
         &self,
         f: F,
     ) -> SignalHandlerId {
         unsafe extern "C" fn drag_motion_trampoline<
             P,
-            F: Fn(&P, &gdk::DragContext, i32, i32, u32) -> glib::signal::Inhibit + 'static,
+            F: Fn(&P, &gdk::DragContext, i32, i32, u32) -> bool + 'static,
         >(
             this: *mut ffi::GtkWidget,
             context: *mut gdk::ffi::GdkDragContext,


### PR DESCRIPTION
As described in #358, unlike most `bool`-returning signals on `Widget`, the `drag-motion` and `drag-drop` signals' return values are *not* interpreted as inhibiting further signal propagation. However, the person who wrote their Gir assumed that they were. (Understandably, as the official documentation for these signals is pretty sparse.) This PR modifies them to return `bool` instead of `Inhibit`.

- `drag-motion`: `true` → a drop here will succeed, `false` → a drop here will fail; not `Inhibit`-like, modified
- `drag-drop`: `true` → a drop here succeeded, `false` → a drop here failed; not `Inhibit`-like, modified
- `drag-failed`: `true` → carry out the standard "drag failed" animation, `false` → don't carry out that animation; I left this as `Inhibit` since it seems to fit

I wasn't able to test this PR myself, since my application has a lot of 0.9isms and doesn't compile with 0.13, but the changes do build and (in Rust, anyway) that's strong evidence that they're not *fundamentally* broken...
