### PR TITLE
Expose layout line fields

### DIFF
--- a/pango/src/layout.rs
+++ b/pango/src/layout.rs
@@ -34,6 +34,21 @@ pub struct HitPosition {
 }
 
 impl LayoutLine {
+    // rustdoc-stripper-ignore-next
+    /// The byte index of the start of this line into the text used to create
+    /// the source [`Layout`].
+    ///
+    /// [`Layout`]: crate::Layout
+    pub fn start_index(&self) -> i32 {
+        unsafe { (*self.to_glib_none().0).start_index }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// The length of this line's text, in bytes.
+    pub fn length(&self) -> i32 {
+        unsafe { (*self.to_glib_none().0).length }
+    }
+
     #[doc(alias = "pango_layout_line_x_to_index")]
     pub fn x_to_index(&self, x_pos: i32) -> HitPosition {
         let mut index = 0;


### PR DESCRIPTION
While I was working on #375 I thought it would make sense to fix another problem I've run into, which is that the various fields on the `PangoLayoutLine` struct are not exposed in a friendly way.

This is a draft; it currently includes the commit from #375, and I'll clean it up if & when that patch is merged.

Two questions:

- Is this desirable, and is my approach okay?
- Is there some way I can expose the `resolved_dir` field? In the auto-generated `PangoLayoutLine` struct this field is missing, and there's a comment `// field resolved_dir has incomplete type`. Is this something that I can fix?



