### PR TITLE
Fix use of gflags attribute in the subclass example

### DIFF
--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -36,13 +36,17 @@
 //!     }
 //! }
 //!
+//! // Note that the first `#[glib::gflags(...)]` is the proc-macro invocation,
+//! // while the plain `#[gflags(...)]` inside the braces are just custom attributes that
+//! // get read by the proc-macro, and they must be written exactly like that.
+//!
 //! #[glib::gflags("MyFlags")]
 //! enum MyFlags {
-//!     #[glib::gflags(name = "Flag A", nick = "nick-a")]
+//!     #[gflags(name = "Flag A", nick = "nick-a")]
 //!     A = 0b00000001,
-//!     #[glib::gflags(name = "Flag B")]
+//!     #[gflags(name = "Flag B")]
 //!     B = 0b00000010,
-//!     #[glib::gflags(skip)]
+//!     #[gflags(skip)]
 //!     AB = Self::A.bits() | Self::B.bits(),
 //!     C = 0b00000100,
 //! }


### PR DESCRIPTION
This bit me in https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/490#note_1064620 - the example in the subclass docs seems wrong.