### PR TITLE
Replace _new constructor for Unix/Win32 Input and Output streams

### DIFF
--- a/gio/src/unix_input_stream.rs
+++ b/gio/src/unix_input_stream.rs
@@ -14,9 +14,17 @@ use socket::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 impl UnixInputStream {
     #[allow(clippy::missing_safety_doc)]
     #[doc(alias = "g_unix_input_stream_new")]
-    pub unsafe fn new<T: IntoRawFd>(fd: T) -> UnixInputStream {
+    pub unsafe fn take_fd<T: IntoRawFd>(fd: T) -> UnixInputStream {
         let fd = fd.into_raw_fd();
         let close_fd = true.to_glib();
+        InputStream::from_glib_full(ffi::g_unix_input_stream_new(fd, close_fd)).unsafe_cast()
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    #[doc(alias = "g_unix_input_stream_new")]
+    pub unsafe fn with_fd<T: AsRawFd>(fd: T) -> UnixInputStream {
+        let fd = fd.as_raw_fd();
+        let close_fd = false.to_glib();
         InputStream::from_glib_full(ffi::g_unix_input_stream_new(fd, close_fd)).unsafe_cast()
     }
 }

--- a/gio/src/unix_output_stream.rs
+++ b/gio/src/unix_output_stream.rs
@@ -13,9 +13,16 @@ use socket::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
 impl UnixOutputStream {
     #[doc(alias = "g_unix_output_stream_new")]
-    pub unsafe fn new<T: IntoRawFd>(fd: T) -> UnixOutputStream {
+    pub unsafe fn take_fd<T: IntoRawFd>(fd: T) -> UnixOutputStream {
         let fd = fd.into_raw_fd();
         let close_fd = true.to_glib();
+        OutputStream::from_glib_full(ffi::g_unix_output_stream_new(fd, close_fd)).unsafe_cast()
+    }
+
+    #[doc(alias = "g_unix_output_stream_new")]
+    pub unsafe fn with_fd<T: AsRawFd>(fd: T) -> UnixOutputStream {
+        let fd = fd.as_raw_fd();
+        let close_fd = false.to_glib();
         OutputStream::from_glib_full(ffi::g_unix_output_stream_new(fd, close_fd)).unsafe_cast()
     }
 }

--- a/gio/src/win32_input_stream.rs
+++ b/gio/src/win32_input_stream.rs
@@ -41,9 +41,18 @@ impl fmt::Display for Win32InputStream {
 impl Win32InputStream {
     #[doc(alias = "g_win32_input_stream_new")]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn new<T: IntoRawHandle>(handle: T) -> Win32InputStream {
+    pub unsafe fn take_handle<T: IntoRawHandle>(handle: T) -> Win32InputStream {
         let handle = handle.into_raw_handle();
         let close_handle = true.to_glib();
+        InputStream::from_glib_full(ffi::g_win32_input_stream_new(handle, close_handle))
+            .unsafe_cast()
+    }
+
+    #[doc(alias = "g_win32_input_stream_new")]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn with_handle<T: AsRawHandle>(handle: T) -> Win32InputStream {
+        let handle = handle.as_raw_handle();
+        let close_handle = false.to_glib();
         InputStream::from_glib_full(ffi::g_win32_input_stream_new(handle, close_handle))
             .unsafe_cast()
     }

--- a/gio/src/win32_output_stream.rs
+++ b/gio/src/win32_output_stream.rs
@@ -41,9 +41,18 @@ impl fmt::Display for Win32OutputStream {
 impl Win32OutputStream {
     #[doc(alias = "g_win32_output_stream_new")]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn new<T: IntoRawHandle>(handle: T) -> Win32OutputStream {
+    pub unsafe fn take_handle<T: IntoRawHandle>(handle: T) -> Win32OutputStream {
         let handle = handle.into_raw_handle();
         let close_handle = true.to_glib();
+        OutputStream::from_glib_full(ffi::g_win32_output_stream_new(handle, close_handle))
+            .unsafe_cast()
+    }
+
+    #[doc(alias = "g_win32_output_stream_new")]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn with_handle<T: AsRawHandle>(handle: T) -> Win32OutputStream {
+        let handle = handle.as_raw_handle();
+        let close_handle = false.to_glib();
         OutputStream::from_glib_full(ffi::g_win32_output_stream_new(handle, close_handle))
             .unsafe_cast()
     }


### PR DESCRIPTION
Add two variants, take_fd/handle and with_fd/handle which respectively
take ownership or not of the fd/handle. This models the "close"
boolean of the C api.

Fixes https://github.com/gtk-rs/gtk-rs/issues/381