### PR TITLE
generator: Iterate gir directories passed on the command line

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -79,9 +79,9 @@ def regen_crates(path, conf):
     elif path.match("Gir*.toml"):
         print('==> Regenerating "{}"...'.format(path))
 
-        args = [conf.gir_path, "-c", path, "-o", path.parent]
-        if len(conf.gir_files_paths) > 0:
-            args += ["-d"] + [conf.gir_files_paths]
+        args = [conf.gir_path, "-c", path, "-o", path.parent] + [
+            d for path in conf.gir_files_paths for d in ("-d", path)
+        ]
         if path.parent.name.endswith("sys"):
             args.extend(["-m", "sys"])
         error = False
@@ -136,7 +136,7 @@ def parse_args():
     )
     parser.add_argument(
         "--gir-files-directories",
-        nargs='+', # If the option is used, we expect at least one folder!
+        nargs="+",  # If the option is used, we expect at least one folder!
         dest="gir_files_paths",
         default=[],
         type=directory_path,
@@ -165,7 +165,7 @@ def parse_args():
 def main():
     conf = parse_args()
 
-    if len(conf.gir_files_paths) == 0:
+    if not conf.gir_files_paths:
         if def_check_submodule(DEFAULT_GIR_FILES_DIRECTORY, conf) == FAILURE:
             return 1
 


### PR DESCRIPTION
This change cleans up handling of the default gir directory, and makes sure the `-d` flag is prepended to every path. Before the command would contain a single `-d` flag followed by a `list` of paths, which cannot be passed to an executable verbatim:

    The following error occurred: expected str, bytes or os.PathLike object, not list
    Do you want to continue? [y/N] ^CTraceback (most recent call last):
      File "./generator.py", line 189, in <module>

Fixes: c33495c ("Don't set a default value for the -d option")

CC @GuillaumeGomez
