### PR TITLE
pango: Fix x_to_index docs

### DIFF
--- a/pango/src/layout.rs
+++ b/pango/src/layout.rs
@@ -11,8 +11,7 @@ pub struct HitPosition {
     // rustdoc-stripper-ignore-next
     /// The UTF-8 byte offset of the grapheme closest to the position.
     ///
-    /// This position is relative to the start of the line, not the start
-    /// of the [`Layout`]'s text.
+    /// This position is relative to the start of the [`Layout`]'s text.
     ///
     /// [`Layout`]: crate::Layout
     pub index: i32,


### PR DESCRIPTION
My understanding was that the hit positions were relative to the
start of the line, but testing shows that they are relative to
the start of the full text.