### PR TITLE
Fix clone macro docs

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -136,7 +136,7 @@ use syn::{parse_macro_input, DeriveInput, LitStr};
 ///
 /// Or by using `@default-panic` (if the value fails to get upgraded, it'll panic):
 ///
-/// ```compile_fail
+/// ```should_panic
 /// # use glib_macros::clone;
 /// # use std::rc::Rc;
 /// # let v = Rc::new(1);

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -136,7 +136,7 @@ use syn::{parse_macro_input, DeriveInput, LitStr};
 ///
 /// Or by using `@default-panic` (if the value fails to get upgraded, it'll panic):
 ///
-/// ```run_fail
+/// ```compile_fail
 /// # use glib_macros::clone;
 /// # use std::rc::Rc;
 /// # let v = Rc::new(1);


### PR DESCRIPTION
It referenced a "run_fail" attribute, which does not seem to exist.