### PR TITLE
gio: do not take args in application.run()

### DIFF
--- a/examples/accessibility/main.rs
+++ b/examples/accessibility/main.rs
@@ -1,8 +1,6 @@
 use gtk::prelude::*;
 use gtk::{atk, gio};
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
 
@@ -51,5 +49,5 @@ fn main() {
         build_ui(app);
     });
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/basic_subclass/main.rs
+++ b/examples/basic_subclass/main.rs
@@ -8,6 +8,5 @@ fn main() {
 
     let app = simple_application::SimpleApplication::new();
 
-    let args: Vec<String> = std::env::args().collect();
-    app.run(&args);
+    app.run();
 }

--- a/examples/basics/main.rs
+++ b/examples/basics/main.rs
@@ -1,7 +1,5 @@
 use gtk::prelude::*;
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
 
@@ -24,5 +22,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/builder_pattern/main.rs
+++ b/examples/builder_pattern/main.rs
@@ -1,7 +1,5 @@
 use gtk::prelude::*;
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindowBuilder::new()
         .application(application)
@@ -29,5 +27,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/cairo_test/main.rs
+++ b/examples/cairo_test/main.rs
@@ -1,4 +1,3 @@
-use std::env::args;
 use std::f64::consts::PI;
 
 use gtk::prelude::*;
@@ -96,7 +95,7 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }
 
 pub fn drawable<F>(application: &gtk::Application, width: i32, height: i32, draw_fn: F)

--- a/examples/cairo_threads/main.rs
+++ b/examples/cairo_threads/main.rs
@@ -2,7 +2,6 @@ mod drawing;
 pub mod image;
 
 use std::cell::RefCell;
-use std::env::args;
 use std::rc::Rc;
 use std::sync::mpsc;
 use std::thread;
@@ -26,7 +25,7 @@ fn main() {
     .expect("Initialization failed...");
 
     application.connect_activate(build_ui);
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }
 
 fn build_ui(application: &gtk::Application) {

--- a/examples/child_properties/main.rs
+++ b/examples/child_properties/main.rs
@@ -3,8 +3,6 @@ use gtk::prelude::*;
 use gtk::Orientation::Vertical;
 use gtk::{ApplicationWindow, Button, Label, PackType};
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let vbox = gtk::Box::new(Vertical, 0);
 
@@ -55,5 +53,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/clipboard_simple/main.rs
+++ b/examples/clipboard_simple/main.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::env::args;
 
 use gtk::prelude::*;
 use gtk::{gdk, gio};
@@ -134,5 +133,5 @@ fn main() {
     });
     application.connect_activate(|_| {});
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/clock/main.rs
+++ b/examples/clock/main.rs
@@ -2,8 +2,6 @@ use chrono::Local;
 use gtk::glib;
 use gtk::prelude::*;
 
-use std::env::args;
-
 fn current_time() -> String {
     return format!("{}", Local::now().format("%Y-%m-%d %H:%M:%S"));
 }
@@ -43,5 +41,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/clone_macro/main.rs
+++ b/examples/clone_macro/main.rs
@@ -50,5 +50,5 @@ fn main() {
         }));
     }
 
-    application.run(&[]);
+    application.run();
 }

--- a/examples/communication_thread/main.rs
+++ b/examples/communication_thread/main.rs
@@ -2,7 +2,6 @@ use futures::{channel::mpsc, StreamExt};
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::{ApplicationWindow, Label};
-use std::env::args;
 use std::thread;
 
 fn main() {
@@ -12,7 +11,7 @@ fn main() {
     )
     .expect("Initialization failed...");
     application.connect_activate(build_ui);
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }
 
 fn build_ui(application: &gtk::Application) {

--- a/examples/composite_template/main.rs
+++ b/examples/composite_template/main.rs
@@ -16,5 +16,5 @@ fn main() {
         win.show();
     });
 
-    application.run(&std::env::args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/css/main.rs
+++ b/examples/css/main.rs
@@ -1,8 +1,6 @@
 use gtk::prelude::*;
 use gtk::{gdk, gio};
 
-use std::env::args;
-
 fn main() {
     let application = gtk::Application::new(Some("com.github.css"), gio::ApplicationFlags::empty())
         .expect("Initialization failed...");
@@ -25,7 +23,7 @@ fn main() {
         build_ui(app);
     });
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }
 
 fn build_ui(application: &gtk::Application) {

--- a/examples/dialog_async/main.rs
+++ b/examples/dialog_async/main.rs
@@ -1,7 +1,6 @@
 use gtk::glib;
 use gtk::prelude::*;
 
-use std::env::args;
 fn main() {
     let application = gtk::ApplicationBuilder::new()
         .application_id("com.github.gtk-rs.examples.dialog_async")
@@ -9,7 +8,7 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }
 
 fn build_ui(application: &gtk::Application) {

--- a/examples/drag_drop/main.rs
+++ b/examples/drag_drop/main.rs
@@ -1,8 +1,6 @@
 use gtk::gdk;
 use gtk::prelude::*;
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     // Configure button as drag source for text
     let button = gtk::Button::with_label("Drag here");
@@ -49,5 +47,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/drag_drop_text_view/main.rs
+++ b/examples/drag_drop_text_view/main.rs
@@ -1,5 +1,3 @@
-use std::env::args;
-
 use gtk::prelude::*;
 use gtk::{gdk, gio};
 use gtk::{DestDefaults, TargetFlags};
@@ -70,5 +68,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/entry_completion/main.rs
+++ b/examples/entry_completion/main.rs
@@ -1,8 +1,6 @@
 use gtk::prelude::*;
 use gtk::{gio, glib};
 
-use std::env::args;
-
 struct Data {
     description: String,
 }
@@ -95,5 +93,5 @@ fn main() {
     application.add_action(&quit);
 
     // Run the application
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/grid/main.rs
+++ b/examples/grid/main.rs
@@ -4,8 +4,6 @@ use gtk::glib;
 use gtk::prelude::*;
 use gtk::{ApplicationWindow, Builder, Button, Grid};
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let glade_src = include_str!("grid.ui");
     let builder = Builder::from_string(glade_src);
@@ -36,5 +34,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/gtk_builder_basics/main.rs
+++ b/examples/gtk_builder_basics/main.rs
@@ -2,8 +2,6 @@ use gtk::glib;
 use gtk::prelude::*;
 use gtk::{ApplicationWindow, Builder, Button, MessageDialog};
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let glade_src = include_str!("builder_basics.ui");
     let builder = Builder::from_string(glade_src);
@@ -33,5 +31,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/gtk_builder_signal/main.rs
+++ b/examples/gtk_builder_signal/main.rs
@@ -3,8 +3,6 @@ use gtk::prelude::*;
 
 use gtk::{ApplicationWindow, Builder, MessageDialog};
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let glade_src = include_str!("builder_signal.ui");
     let builder = Builder::from_string(glade_src);
@@ -48,5 +46,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/gtk_test/main.rs
+++ b/examples/gtk_test/main.rs
@@ -8,8 +8,6 @@ use gtk::{
     Scale, SpinButton, Spinner, Switch, Window,
 };
 
-use std::env::args;
-
 fn about_clicked(button: &Button, dialog: &AboutDialog) {
     if let Some(window) = button
         .get_toplevel()
@@ -197,5 +195,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/icon_view/main.rs
+++ b/examples/icon_view/main.rs
@@ -1,7 +1,6 @@
 use gtk::prelude::*;
 use gtk::{gdk_pixbuf, glib};
 
-use std::env::args;
 use std::process;
 
 // Convenience Enum for IconView column types
@@ -94,5 +93,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/list_box_model/main.rs
+++ b/examples/list_box_model/main.rs
@@ -183,5 +183,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/list_store/main.rs
+++ b/examples/list_store/main.rs
@@ -1,7 +1,6 @@
 use gtk::glib;
 use gtk::prelude::*;
 
-use std::env::args;
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -320,5 +319,5 @@ fn main() {
 
     application.connect_activate(|_| {});
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/menu_bar/main.rs
+++ b/examples/menu_bar/main.rs
@@ -5,8 +5,6 @@ use gtk::{
     Menu, MenuBar, MenuItem, WindowPosition,
 };
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let window = ApplicationWindow::new(application);
 
@@ -110,5 +108,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/menu_bar_system/main.rs
+++ b/examples/menu_bar_system/main.rs
@@ -2,8 +2,6 @@ use gtk::prelude::*;
 use gtk::AboutDialog;
 use gtk::{gio, glib};
 
-use std::env::args;
-
 fn build_system_menu(application: &gtk::Application) {
     let menu = gio::Menu::new();
     let menu_bar = gio::Menu::new();
@@ -139,5 +137,5 @@ fn main() {
     });
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/multi_threading_context/main.rs
+++ b/examples/multi_threading_context/main.rs
@@ -1,7 +1,6 @@
 use gtk::glib;
 use gtk::prelude::*;
 
-use std::env::args;
 use std::thread;
 use std::time::Duration;
 
@@ -54,5 +53,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/multi_window/main.rs
+++ b/examples/multi_window/main.rs
@@ -3,7 +3,6 @@ use gtk::prelude::*;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::env::args;
 use std::rc::Rc;
 
 fn create_sub_window(
@@ -117,5 +116,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/notebook/main.rs
+++ b/examples/notebook/main.rs
@@ -2,8 +2,6 @@ use gtk::glib;
 use gtk::prelude::*;
 use gtk::{IconSize, Orientation, ReliefStyle, Widget};
 
-use std::env::args;
-
 struct Notebook {
     notebook: gtk::Notebook,
     tabs: Vec<gtk::Box>,
@@ -73,5 +71,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/overlay/main.rs
+++ b/examples/overlay/main.rs
@@ -5,8 +5,6 @@
 use gtk::prelude::*;
 use gtk::{gdk, gio, glib};
 
-use std::env::args;
-
 // Basic CSS: we change background color, we set font color to black and we set it as bold.
 const STYLE: &str = "
 #overlay-label {
@@ -92,5 +90,5 @@ fn main() {
         build_ui(app);
     });
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/pango_attributes/main.rs
+++ b/examples/pango_attributes/main.rs
@@ -1,8 +1,6 @@
 use gtk::pango;
 use gtk::prelude::*;
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
 
@@ -47,5 +45,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/printing/main.rs
+++ b/examples/printing/main.rs
@@ -88,5 +88,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/progress_tracker/main.rs
+++ b/examples/progress_tracker/main.rs
@@ -2,7 +2,6 @@ use gtk::prelude::*;
 use gtk::{gio, glib};
 
 use std::cell::{Cell, RefCell};
-use std::env::args;
 use std::rc::Rc;
 use std::thread;
 use std::time::Duration;
@@ -31,7 +30,7 @@ pub fn main() {
     });
 
     application.connect_activate(|_| {});
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }
 
 pub struct Application {

--- a/examples/sync_widget/main.rs
+++ b/examples/sync_widget/main.rs
@@ -1,8 +1,6 @@
 use gtk::prelude::*;
 use gtk::{glib, Builder};
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let glade_src = include_str!("sync_widgets.ui");
     let builder = Builder::new();
@@ -40,5 +38,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/text_viewer/main.rs
+++ b/examples/text_viewer/main.rs
@@ -1,4 +1,3 @@
-use std::env::args;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -66,5 +65,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/transparent_main_window/main.rs
+++ b/examples/transparent_main_window/main.rs
@@ -2,8 +2,6 @@ use gtk::prelude::*;
 use gtk::{cairo, gdk};
 use gtk::{ApplicationWindow, Button, Fixed};
 
-use std::env::args;
-
 fn build_ui(application: &gtk::Application) {
     let window = ApplicationWindow::new(application);
     set_visual(&window, None);
@@ -33,7 +31,7 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }
 
 fn set_visual(window: &ApplicationWindow, _screen: Option<&gdk::Screen>) {

--- a/examples/tree_view/main.rs
+++ b/examples/tree_view/main.rs
@@ -6,8 +6,6 @@ use gtk::{
     MessageDialog, MessageType, Orientation, TreeStore, TreeView, TreeViewColumn, WindowPosition,
 };
 
-use std::env::args;
-
 fn append_text_column(tree: &TreeView) {
     let column = TreeViewColumn::new();
     let cell = CellRendererText::new();
@@ -120,5 +118,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/tree_view_model_sort/main.rs
+++ b/examples/tree_view_model_sort/main.rs
@@ -1,6 +1,5 @@
 use gtk::prelude::*;
 use gtk::{gio, glib};
-use std::env::args;
 
 fn build_ui(application: &gtk::Application) {
     let window = gtk::ApplicationWindow::new(application);
@@ -57,5 +56,5 @@ fn main() {
             .expect("Initialization failed...");
 
     application.connect_activate(build_ui);
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/examples/tree_view_simple/main.rs
+++ b/examples/tree_view_simple/main.rs
@@ -4,8 +4,6 @@ use gtk::{
     WindowPosition,
 };
 
-use std::env::args;
-
 fn create_and_fill_model() -> ListStore {
     // Creation of a model with two rows.
     let model = ListStore::new(&[u32::static_type(), String::static_type()]);
@@ -100,5 +98,5 @@ fn main() {
 
     application.connect_activate(build_ui);
 
-    application.run(&args().collect::<Vec<_>>());
+    application.run();
 }

--- a/gio/src/application.rs
+++ b/gio/src/application.rs
@@ -12,12 +12,19 @@ use std::mem::transmute;
 
 pub trait ApplicationExtManual {
     #[doc(alias = "g_application_run")]
-    fn run(&self, argv: &[String]) -> i32;
+    fn run(&self) -> i32;
+    #[doc(alias = "g_application_run")]
+    fn run_with_args<S: AsRef<str>>(&self, args: &[S]) -> i32;
     fn connect_open<F: Fn(&Self, &[File], &str) + 'static>(&self, f: F) -> SignalHandlerId;
 }
 
 impl<O: IsA<Application>> ApplicationExtManual for O {
-    fn run(&self, argv: &[String]) -> i32 {
+    fn run(&self) -> i32 {
+        self.run_with_args(&std::env::args().collect::<Vec<_>>())
+    }
+
+    fn run_with_args<S: AsRef<str>>(&self, args: &[S]) -> i32 {
+        let argv: Vec<&str> = args.iter().map(|a| a.as_ref()).collect();
         let argc = argv.len() as i32;
         unsafe {
             ffi::g_application_run(self.as_ref().to_glib_none().0, argc, argv.to_glib_none().0)

--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -561,6 +561,6 @@ mod tests {
 
         app.set_inactivity_timeout(10000);
 
-        assert!(app.run(&["--local".to_string()]) == EXIT_STATUS);
+        assert!(app.run_with_args(&["--local"]) == EXIT_STATUS);
     }
 }

--- a/gtk/src/lib.rs
+++ b/gtk/src/lib.rs
@@ -74,7 +74,7 @@
 //!         // Don't forget to make all widgets visible.
 //!         win.show_all();
 //!     });
-//!     uiapp.run(&env::args().collect::<Vec<_>>());
+//!     uiapp.run();
 //! }
 //! ```
 //!


### PR DESCRIPTION
Passing the args is a C-ism of the API since in C the args are
passed to main(), but in rust they are in std::env, so we can
keep the common case simple.
A run_with_args variant is added for the cases where a caller
wants to process the arg vector before running the app.