### PR TITLE
gtk3 macros: specify syn features

### DIFF
--- a/gtk3-macros/Cargo.toml
+++ b/gtk3-macros/Cargo.toml
@@ -23,5 +23,5 @@ heck = "0.3"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
+syn = { version = "1.0", features = ["full"] }
 proc-macro-crate = "0.1"


### PR DESCRIPTION
This enables the same syn features in gtk3-macros as it is in glib-macros