### PR TITLE
CI: install git docs in a subdir

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,3 +54,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc/
+          keep_files: false
+          destination_dir: git/docs


### PR DESCRIPTION
this would allow us to publish the stable docs in a separate subdir later on