### PR TITLE
gtk: make all with_label and with_mnemonic constructors consistent

### DIFF
--- a/gtk/Gir.toml
+++ b/gtk/Gir.toml
@@ -1315,6 +1315,11 @@ name = "Gtk.Label"
 status = "generate"
 generate_builder = true
     [[object.function]]
+    name = "new_with_mnemonic"
+        [[object.function.parameter]]
+        name = "str"
+        nullable = false
+    [[object.function]]
     name = "get_label"
         [object.function.return]
         nullable = false
@@ -1346,6 +1351,11 @@ generate_builder = true
 name = "Gtk.LinkButton"
 status = "generate"
 generate_builder = true
+    [[object.function]]
+    name = "new_with_label"
+        [[object.function.parameter]]
+        name = "label"
+        nullable = false
     [[object.signal]]
     name = "activate-link"
     inhibit = true

--- a/gtk/src/auto/label.rs
+++ b/gtk/src/auto/label.rs
@@ -39,7 +39,7 @@ impl Label {
     }
 
     #[doc(alias = "gtk_label_new_with_mnemonic")]
-    pub fn with_mnemonic(str: Option<&str>) -> Label {
+    pub fn with_mnemonic(str: &str) -> Label {
         assert_initialized_main_thread!();
         unsafe {
             Widget::from_glib_none(ffi::gtk_label_new_with_mnemonic(str.to_glib_none().0))

--- a/gtk/src/auto/link_button.rs
+++ b/gtk/src/auto/link_button.rs
@@ -41,7 +41,7 @@ impl LinkButton {
     }
 
     #[doc(alias = "gtk_link_button_new_with_label")]
-    pub fn with_label(uri: &str, label: Option<&str>) -> LinkButton {
+    pub fn with_label(uri: &str, label: &str) -> LinkButton {
         assert_initialized_main_thread!();
         unsafe {
             Widget::from_glib_none(ffi::gtk_link_button_new_with_label(


### PR DESCRIPTION
Never take Option, since one can simply use new() if they do not
want to specify a string.
Fixes https://github.com/gtk-rs/gtk-rs/issues/133