### PR TITLE
glib: Remove glib::TypedValue

### DIFF
--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -108,7 +108,7 @@ use std::ffi::CStr;
 
 pub use self::enums::{EnumClass, EnumValue, FlagsBuilder, FlagsClass, FlagsValue, UserDirectory};
 pub use self::types::{ILong, StaticType, Type, ULong};
-pub use self::value::{SendValue, ToSendValue, ToValue, TypedValue, Value};
+pub use self::value::{SendValue, ToSendValue, ToValue, Value};
 pub use self::variant::{FromVariant, StaticVariantType, ToVariant, Variant};
 pub use self::variant_dict::VariantDict;
 pub use self::variant_iter::VariantIter;


### PR DESCRIPTION
It's not very useful in practice and there seems to be no usage of it.

If a "typed value" is needed then the proper Rust type can be used as
well and there's no reason to keep it in a GValue wrapper.

----

Extracted from https://github.com/gtk-rs/gtk-rs/pull/31 for easier reviewing and smaller PRs.