### PR TITLE
CI: publish release docs in a separate subdir

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,8 @@ jobs:
           args: -p atk -p atk-sys -p cairo-rs -p cairo-sys-rs -p gdk -p gdk-sys -p gdk-pixbuf -p gdk-pixbuf-sys -p gdkx11 -p gdkx11-sys -p gio -p gio-sys -p glib -p gobject-sys -p glib-sys -p glib-macros -p graphene-rs -p graphene-sys -p gtk -p gtk3-macros -p gtk-sys -p pango -p pango-sys -p pangocairo -p pangocairo-sys --features "dox,embed-lgpl-docs" --no-deps
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
-      - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "releases" ]; then echo 'stable'; else echo 'git'; fi)" >> ${GITHUB_ENV}
+      - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "release" ]; then echo 'stable'; else echo 'git'; fi)" >> ${GITHUB_ENV}
+      - run: echo ${{ env.DEST }}
       - name: deploy
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release' }}
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches: [master]
   pull_request:
+  release:
+    types: [published]
 
 name: docs
 
@@ -47,12 +49,12 @@ jobs:
           args: -p atk -p atk-sys -p cairo-rs -p cairo-sys-rs -p gdk -p gdk-sys -p gdk-pixbuf -p gdk-pixbuf-sys -p gdkx11 -p gdkx11-sys -p gio -p gio-sys -p glib -p gobject-sys -p glib-sys -p glib-macros -p graphene-rs -p graphene-sys -p gtk -p gtk3-macros -p gtk-sys -p pango -p pango-sys -p pangocairo -p pangocairo-sys --features "dox,embed-lgpl-docs" --no-deps
         env:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
-
+      - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "releases" ]; then echo 'stable'; else echo 'git'; fi)" >> ${GITHUB_ENV}
       - name: deploy
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc/
           keep_files: false
-          destination_dir: git/docs
+          destination_dir: ${{ env.DEST }}/docs


### PR DESCRIPTION
With this the job will start automatically when a release is published and the docs will hopefully be deployed to the stable subdirectory instead of the git one. 