### PR TITLE
glib: glib-macros: add SharedType and Shared derive macro

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.48.0"
+          - "1.51.0"
         conf:
           - { name: "atk", features: "v2_34", nightly: "--all-features", test_sys: true }
           - { name: "cairo", features: "png,pdf,svg,ps,use_glib,v1_16,freetype,script,xcb,xlib,win32-surface", nightly: "--features 'png,pdf,svg,ps,use_glib,v1_16,freetype,script,xcb,xlib,win32-surface'", test_sys: true }
@@ -119,7 +119,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.48.0"
+          - "1.51.0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ information about each crate, please refer to their `README.md` file in their di
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/atk/README.md
+++ b/atk/README.md
@@ -5,7 +5,7 @@ __Rust__ bindings and wrappers for __Atk__, part of [gtk-rs](https://github.com/
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/cairo/README.md
+++ b/cairo/README.md
@@ -6,7 +6,7 @@ __Rust__ bindings for Rust and wrappers for __Cairo__.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/gdk-pixbuf/README.md
+++ b/gdk-pixbuf/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __Gdk-Pixbuf__.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/gdk/README.md
+++ b/gdk/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __GDK__, part of [gtk-rs](https://github.com/
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/gdkx11/README.md
+++ b/gdkx11/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __GDKX11__, part of [gtk-rs](https://github.c
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/gio/README.md
+++ b/gio/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __GIO__, part of [gtk-rs](https://github.com/
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/glib-macros/src/gboxed_shared_derive.rs
+++ b/glib-macros/src/gboxed_shared_derive.rs
@@ -1,0 +1,181 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::utils::{crate_ident_new, find_attribute_meta, find_nested_meta, parse_type_name};
+use proc_macro2::{Ident, TokenStream};
+use proc_macro_error::abort_call_site;
+use quote::quote;
+
+fn gen_impl_set_value_optional(name: &Ident, crate_ident: &Ident) -> TokenStream {
+    let refcounted_type_prefix = refcounted_type_prefix(name, crate_ident);
+
+    quote! {
+        impl #crate_ident::value::SetValueOptional for #name {
+            unsafe fn set_value_optional(value: &mut #crate_ident::value::Value, this: Option<&Self>) {
+                let ptr = match this {
+                    Some(this) => #refcounted_type_prefix::into_raw(this.0.clone()),
+                    None => std::ptr::null(),
+                };
+
+                #crate_ident::gobject_ffi::g_value_take_boxed(
+                    #crate_ident::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
+                    ptr as *mut _,
+                );
+            }
+        }
+    }
+}
+
+fn gen_impl_from_value(name: &Ident, crate_ident: &Ident) -> TokenStream {
+    let refcounted_type_prefix = refcounted_type_prefix(name, crate_ident);
+
+    quote! {
+        impl<'a> #crate_ident::value::FromValue<'a> for #name {
+            unsafe fn from_value(value: &'a #crate_ident::value::Value) -> Self {
+                let ptr = #crate_ident::gobject_ffi::g_value_dup_boxed(
+                    #crate_ident::translate::ToGlibPtr::to_glib_none(value).0,
+                );
+                assert!(!ptr.is_null());
+                #name(#refcounted_type_prefix::from_raw(ptr as *mut _))
+            }
+        }
+    }
+}
+
+fn gen_ptr_to_option(name: &Ident, nullable: bool, crate_ident: &Ident) -> TokenStream {
+    let refcounted_type_prefix = refcounted_type_prefix(name, crate_ident);
+
+    if nullable {
+        quote! {
+            if ptr.is_null() {
+                None
+            } else {
+                Some(#name(#refcounted_type_prefix::from_raw(ptr as *mut _)))
+            }
+        }
+    } else {
+        quote! {
+            assert!(!ptr.is_null());
+            Some(#name(#refcounted_type_prefix::from_raw(ptr as *mut _)))
+        }
+    }
+}
+
+fn refcounted_type(input: &syn::DeriveInput) -> Option<&syn::TypePath> {
+    let fields = match &input.data {
+        syn::Data::Struct(s) => &s.fields,
+        _ => return None,
+    };
+
+    let unnamed = match fields {
+        syn::Fields::Unnamed(u) if u.unnamed.len() == 1 => &u.unnamed[0],
+        _ => return None,
+    };
+
+    let refcounted = match &unnamed.ty {
+        syn::Type::Path(p) => p,
+        _ => return None,
+    };
+
+    Some(refcounted)
+}
+
+fn refcounted_type_prefix(name: &Ident, crate_ident: &Ident) -> proc_macro2::TokenStream {
+    quote! {
+        <<#name as #crate_ident::subclass::shared::SharedType>::RefCountedType as #crate_ident::subclass::shared::RefCounted>
+    }
+}
+
+pub fn impl_gshared_boxed(input: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    let refcounted_type = match refcounted_type(input) {
+        Some(p) => p,
+        _ => abort_call_site!("derive(GSharedBoxed) requires struct MyStruct(T: RefCounted)"),
+    };
+
+    let name = &input.ident;
+    let gtype_name = match parse_type_name(&input, "gshared_boxed") {
+        Ok(v) => v,
+        Err(e) => abort_call_site!(
+            "{}: derive(GSharedBoxed) requires #[gshared_boxed(type_name = \"SharedTypeName\")]",
+            e
+        ),
+    };
+
+    let meta = find_attribute_meta(&input.attrs, "gshared_boxed")
+        .unwrap()
+        .unwrap();
+    let nullable = find_nested_meta(&meta, "nullable").is_some();
+    let crate_ident = crate_ident_new();
+    let refcounted_type_prefix = refcounted_type_prefix(name, &crate_ident);
+    let ptr_to_option = gen_ptr_to_option(name, nullable, &crate_ident);
+
+    let impl_from_value = if !nullable {
+        gen_impl_from_value(name, &crate_ident)
+    } else {
+        quote! {}
+    };
+
+    let impl_set_value_optional = if nullable {
+        gen_impl_set_value_optional(name, &crate_ident)
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        impl #crate_ident::subclass::shared::SharedType for #name {
+            const NAME: &'static str = #gtype_name;
+
+            type RefCountedType = #refcounted_type;
+
+            fn get_type() -> #crate_ident::Type {
+                static mut TYPE_: #crate_ident::Type = #crate_ident::Type::INVALID;
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
+
+                ONCE.call_once(|| {
+                    let type_ = #crate_ident::subclass::shared::register_shared_type::<Self>();
+                    unsafe {
+                        TYPE_ = type_;
+                    }
+                });
+
+                unsafe { TYPE_ }
+            }
+
+            fn from_refcounted(this: Self::RefCountedType) -> Self {
+                Self(this)
+            }
+
+            fn into_refcounted(self) -> Self::RefCountedType {
+                self.0
+            }
+        }
+
+        impl #crate_ident::StaticType for #name {
+            fn static_type() -> #crate_ident::Type {
+                <#name as #crate_ident::subclass::shared::SharedType>::get_type()
+            }
+        }
+
+        impl #crate_ident::value::SetValue for #name {
+            unsafe fn set_value(value: &mut #crate_ident::value::Value, this: &Self) {
+                let ptr = #refcounted_type_prefix::into_raw(this.0.clone());
+                #crate_ident::gobject_ffi::g_value_take_boxed(
+                    #crate_ident::translate::ToGlibPtrMut::to_glib_none_mut(value).0,
+                    ptr as *mut _,
+                );
+            }
+        }
+
+        #impl_set_value_optional
+
+        impl<'a> #crate_ident::value::FromValueOptional<'a> for #name {
+            unsafe fn from_value_optional(value: &'a #crate_ident::value::Value) -> Option<Self> {
+                let ptr = #crate_ident::gobject_ffi::g_value_dup_boxed(
+                    #crate_ident::translate::ToGlibPtr::to_glib_none(value).0,
+                );
+                #ptr_to_option
+            }
+        }
+
+        #impl_from_value
+    }
+}

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -3,6 +3,7 @@
 mod clone;
 mod downgrade_derive;
 mod gboxed_derive;
+mod gboxed_shared_derive;
 mod genum_derive;
 mod gerror_domain_derive;
 mod gflags_attribute;
@@ -297,6 +298,34 @@ pub fn gerror_domain_derive(input: TokenStream) -> TokenStream {
 pub fn gboxed_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let gen = gboxed_derive::impl_gboxed(&input);
+    gen.into()
+}
+
+/// Derive macro for defining a [`SharedType`]`::get_type` function and
+/// the [`glib::Value`] traits.
+///
+/// # Example
+///
+/// ```
+/// use glib::prelude::*;
+/// use glib::subclass::prelude::*;
+///
+/// #[derive(Clone, Debug, PartialEq, Eq)]
+/// struct MySharedInner {
+///   foo: String,
+/// }
+/// #[derive(Clone, Debug, PartialEq, Eq, glib::GSharedBoxed)]
+/// #[gshared_boxed(type_name = "MyShared")]
+/// struct MyShared(std::sync::Arc<MySharedInner>);
+/// ```
+///
+/// [`SharedType`]: subclass/shared/trait.SharedType.html
+/// [`glib::Value`]: value/struct.Value.html
+#[proc_macro_derive(GSharedBoxed, attributes(gshared_boxed))]
+#[proc_macro_error]
+pub fn gshared_boxed_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let gen = gboxed_shared_derive::impl_gshared_boxed(&input);
     gen.into()
 }
 

--- a/glib/README.md
+++ b/glib/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __GLib__, part of [gtk-rs](https://github.com
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -88,6 +88,7 @@ pub use once_cell;
 
 pub use glib_macros::{
     clone, gflags, object_interface, object_subclass, Downgrade, GBoxed, GEnum, GErrorDomain,
+    GSharedBoxed,
 };
 
 pub use self::array::Array;

--- a/glib/src/subclass/boxed.rs
+++ b/glib/src/subclass/boxed.rs
@@ -67,7 +67,9 @@ pub fn register_boxed_type<T: BoxedType>() -> crate::Type {
 #[cfg(test)]
 mod test {
     use super::*;
-    // GBoxed macro assumes 'glib' is in scope
+    // We rename the current crate as glib, since the macros in glib-macros
+    // generate the glib namespace through the crate_ident_new utility,
+    // and that returns `glib` (and not `crate`) when called inside the glib crate
     use crate as glib;
     use crate::value::ToValue;
 

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -249,6 +249,8 @@ pub mod object;
 #[macro_use]
 pub mod boxed;
 
+pub mod shared;
+
 pub mod signal;
 
 pub mod prelude {
@@ -256,6 +258,7 @@ pub mod prelude {
     pub use super::boxed::BoxedType;
     pub use super::interface::{ObjectInterface, ObjectInterfaceExt, ObjectInterfaceType};
     pub use super::object::{ObjectClassSubclassExt, ObjectImpl, ObjectImplExt};
+    pub use super::shared::{RefCounted, SharedType};
     pub use super::types::{
         ClassStruct, InstanceStruct, IsImplementable, IsSubclassable, ObjectSubclass,
         ObjectSubclassExt, ObjectSubclassType,

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -224,6 +224,9 @@ mod test {
     use super::super::super::object::ObjectExt;
     use super::super::super::value::{ToValue, Value};
     use super::*;
+    // We rename the current crate as glib, since the macros in glib-macros
+    // generate the glib namespace through the crate_ident_new utility,
+    // and that returns `glib` (and not `crate`) when called inside the glib crate
     use crate as glib;
     use crate::StaticType;
 

--- a/glib/src/subclass/shared.rs
+++ b/glib/src/subclass/shared.rs
@@ -25,9 +25,8 @@ where
     type InnerType = T;
 
     unsafe fn ref_(this: *const Self::InnerType) -> *const Self::InnerType {
-        use std::mem::ManuallyDrop;
-        let this_rc = ManuallyDrop::new(std::rc::Rc::from_raw(this));
-        std::rc::Rc::into_raw(ManuallyDrop::take(&mut this_rc.clone()))
+        std::sync::Arc::increment_strong_count(this);
+        this
     }
 
     unsafe fn into_raw(self) -> *const Self::InnerType {

--- a/glib/src/subclass/shared.rs
+++ b/glib/src/subclass/shared.rs
@@ -1,0 +1,230 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+//! Module for registering shared types for Rust types.
+
+use crate::translate::*;
+
+pub unsafe trait RefCounted: Clone + Sized + 'static {
+    /// The inner type
+    type InnerType;
+
+    /// The function used to increment the inner type refcount
+    unsafe fn ref_(this: *const Self::InnerType) -> *const Self::InnerType;
+
+    /// Converts the RefCounted object to a raw pointer to InnerType
+    unsafe fn into_raw(self) -> *const Self::InnerType;
+
+    /// Converts a raw pointer to InnerType to a RefCounted object
+    unsafe fn from_raw(this: *const Self::InnerType) -> Self;
+}
+
+unsafe impl<T> RefCounted for std::sync::Arc<T>
+where
+    T: 'static,
+{
+    type InnerType = T;
+
+    unsafe fn ref_(this: *const Self::InnerType) -> *const Self::InnerType {
+        use std::mem::ManuallyDrop;
+        let this_rc = ManuallyDrop::new(std::rc::Rc::from_raw(this));
+        std::rc::Rc::into_raw(ManuallyDrop::take(&mut this_rc.clone()))
+    }
+
+    unsafe fn into_raw(self) -> *const Self::InnerType {
+        std::sync::Arc::into_raw(self)
+    }
+
+    unsafe fn from_raw(this: *const Self::InnerType) -> Self {
+        std::sync::Arc::from_raw(this)
+    }
+}
+
+unsafe impl<T> RefCounted for std::rc::Rc<T>
+where
+    T: 'static,
+{
+    type InnerType = T;
+
+    unsafe fn ref_(this: *const Self::InnerType) -> *const Self::InnerType {
+        use std::mem::ManuallyDrop;
+        let this_rc = ManuallyDrop::new(std::rc::Rc::from_raw(this));
+        std::rc::Rc::into_raw(ManuallyDrop::take(&mut this_rc.clone()))
+    }
+
+    unsafe fn into_raw(self) -> *const Self::InnerType {
+        std::rc::Rc::into_raw(self)
+    }
+
+    unsafe fn from_raw(this: *const Self::InnerType) -> Self {
+        std::rc::Rc::from_raw(this)
+    }
+}
+
+/// Trait for defining shared types.
+///
+/// Links together the type name with the type itself.
+///
+/// See [`register_shared_type`] for registering an implementation of this trait
+/// with the type system.
+///
+/// [`register_shared_type`]: fn.register_shared_type.html
+pub trait SharedType: Clone + Sized + 'static {
+    /// Shared type name.
+    ///
+    /// This must be unique in the whole process.
+    const NAME: &'static str;
+
+    /// The inner refcounted type
+    type RefCountedType: RefCounted;
+
+    /// Returns the type ID.
+    ///
+    /// This is usually defined via the [`Shared!`] derive macro.
+    ///
+    /// [`Shared!`]: ../../derive.Shared.html
+    fn get_type() -> crate::Type;
+
+    /// Converts the SharedType into its inner RefCountedType
+    fn into_refcounted(self) -> Self::RefCountedType;
+
+    /// Constructs a SharedType from a RefCountedType
+    fn from_refcounted(this: Self::RefCountedType) -> Self;
+}
+
+/// Register a boxed `glib::Type` ID for `T`.
+///
+/// This must be called only once and will panic on a second call.
+///
+/// See [`Shared!`] for defining a function that ensures that
+/// this is only called once and returns the type id.
+///
+/// [`Shared!`]: ../../derive.Shared.html
+pub fn register_shared_type<T: SharedType>() -> crate::Type {
+    unsafe {
+        use std::ffi::CString;
+        unsafe extern "C" fn shared_ref<T: SharedType>(v: ffi::gpointer) -> ffi::gpointer {
+            T::RefCountedType::ref_(v as *const <T::RefCountedType as RefCounted>::InnerType)
+                as ffi::gpointer
+        }
+        unsafe extern "C" fn shared_unref<T: SharedType>(v: ffi::gpointer) {
+            let _ = T::RefCountedType::from_raw(
+                v as *const <T::RefCountedType as RefCounted>::InnerType,
+            );
+        }
+
+        let type_name = CString::new(T::NAME).unwrap();
+        if gobject_ffi::g_type_from_name(type_name.as_ptr()) != gobject_ffi::G_TYPE_INVALID {
+            panic!(
+                "Type {} has already been registered",
+                type_name.to_str().unwrap()
+            );
+        }
+
+        from_glib(gobject_ffi::g_boxed_type_register_static(
+            type_name.as_ptr(),
+            Some(shared_ref::<T>),
+            Some(shared_unref::<T>),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    // We rename the current crate as glib, since the macros in glib-macros
+    // generate the glib namespace through the crate_ident_new utility,
+    // and that returns `glib` (and not `crate`) when called inside the glib crate
+    use crate as glib;
+    use crate::value::ToValue;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct MySharedInner {
+        foo: String,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, glib::GSharedBoxed)]
+    #[gshared_boxed(type_name = "MySharedArc")]
+    struct MySharedArc(std::sync::Arc<MySharedInner>);
+
+    #[derive(Clone, Debug, PartialEq, Eq, glib::GSharedBoxed)]
+    #[gshared_boxed(type_name = "MySharedRc")]
+    struct MySharedRc(std::rc::Rc<MySharedInner>);
+
+    #[test]
+    fn test_register() {
+        assert_ne!(crate::Type::INVALID, MySharedArc::get_type());
+        assert_ne!(crate::Type::INVALID, MySharedRc::get_type());
+    }
+
+    #[test]
+    fn test_value_arc() {
+        assert_ne!(crate::Type::INVALID, MySharedArc::get_type());
+
+        let b = MySharedArc::from_refcounted(std::sync::Arc::new(MySharedInner {
+            foo: String::from("abc"),
+        }));
+        let v = b.to_value();
+        let b2 = v.get_some::<MySharedArc>().unwrap();
+        assert!(std::sync::Arc::ptr_eq(&b.0, &b2.0));
+    }
+
+    #[test]
+    fn test_value_rc() {
+        assert_ne!(crate::Type::INVALID, MySharedRc::get_type());
+
+        let b = MySharedRc::from_refcounted(std::rc::Rc::new(MySharedInner {
+            foo: String::from("abc"),
+        }));
+        let v = b.to_value();
+        let b2 = v.get_some::<MySharedRc>().unwrap();
+        assert!(std::rc::Rc::ptr_eq(&b.0, &b2.0));
+    }
+
+    #[test]
+    fn same_ffi_pointer_arc() {
+        assert_ne!(crate::Type::INVALID, MySharedArc::get_type());
+
+        let b = MySharedArc::from_refcounted(std::sync::Arc::new(MySharedInner {
+            foo: String::from("abc"),
+        }));
+
+        let inner_raw_ptr = std::sync::Arc::into_raw(b.clone().0);
+
+        assert_eq!(std::sync::Arc::strong_count(&b.0), 2);
+
+        let inner_raw_ptr_clone =
+            unsafe { <MySharedArc as SharedType>::RefCountedType::ref_(inner_raw_ptr) };
+
+        assert_eq!(std::sync::Arc::strong_count(&b.0), 3);
+        assert!(std::ptr::eq(inner_raw_ptr, inner_raw_ptr_clone));
+
+        let _ = unsafe { <MySharedArc as SharedType>::RefCountedType::from_raw(inner_raw_ptr) };
+        let _ =
+            unsafe { <MySharedArc as SharedType>::RefCountedType::from_raw(inner_raw_ptr_clone) };
+        assert_eq!(std::sync::Arc::strong_count(&b.0), 1);
+    }
+
+    #[test]
+    fn same_ffi_pointer_rc() {
+        assert_ne!(crate::Type::INVALID, MySharedRc::get_type());
+
+        let b = MySharedRc::from_refcounted(std::rc::Rc::new(MySharedInner {
+            foo: String::from("abc"),
+        }));
+
+        let inner_raw_ptr = std::rc::Rc::into_raw(b.clone().0);
+
+        assert_eq!(std::rc::Rc::strong_count(&b.0), 2);
+
+        let inner_raw_ptr_clone =
+            unsafe { <MySharedRc as SharedType>::RefCountedType::ref_(inner_raw_ptr) };
+
+        assert_eq!(std::rc::Rc::strong_count(&b.0), 3);
+        assert!(std::ptr::eq(inner_raw_ptr, inner_raw_ptr_clone));
+
+        let _ = unsafe { <MySharedRc as SharedType>::RefCountedType::from_raw(inner_raw_ptr) };
+        let _ =
+            unsafe { <MySharedRc as SharedType>::RefCountedType::from_raw(inner_raw_ptr_clone) };
+        assert_eq!(std::rc::Rc::strong_count(&b.0), 1);
+    }
+}

--- a/graphene/README.md
+++ b/graphene/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __Graphene__, part of [gtk-rs](https://github
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/gtk/README.md
+++ b/gtk/README.md
@@ -6,7 +6,7 @@ __Rust__ bindings and wrappers for __GTK 3__, part of [gtk-rs](https://github.co
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Building
 

--- a/pango/README.md
+++ b/pango/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __Pango__, part of [gtk-rs](https://github.co
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 

--- a/pangocairo/README.md
+++ b/pangocairo/README.md
@@ -4,7 +4,7 @@ __Rust__ bindings and wrappers for __PangoCairo__, part of [gtk-rs](https://gith
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.48.0`.
+Currently, the minimum supported Rust version is `1.51.0`.
 
 ## Documentation
 


### PR DESCRIPTION
Added a SharedType trait that allows implementing reference-counted
types in terms os std::sync::Arc. In particular, the ffi methods that
increment reference counting can return always the same pointer value.
Also, added a `Shared` derive macro, similar to the existing `GBoxed`
one, that simplifies the creation of Shared objects.