### PR TITLE
glib: mark ParamSpecType trait as unsafe

### DIFF
--- a/gdk/src/event.rs
+++ b/gdk/src/event.rs
@@ -400,7 +400,7 @@ impl fmt::Debug for Event {
 }
 
 /// A helper trait implemented by all event subtypes.
-pub trait FromEvent: Sized {
+pub unsafe trait FromEvent: Sized {
     fn is(ev: &Event) -> bool;
     fn from(ev: Event) -> Result<Self, Event>;
 }
@@ -482,7 +482,7 @@ event_wrapper!(Event, GdkEventAny);
 
 macro_rules! event_subtype {
     ($name:ident, $($ty:path)|+) => {
-        impl crate::event::FromEvent for $name {
+        unsafe impl crate::event::FromEvent for $name {
             #[inline]
             fn is(ev: &crate::event::Event) -> bool {
                 skip_assert_initialized!();
@@ -516,7 +516,7 @@ macro_rules! event_subtype {
     };
 }
 
-impl FromEvent for Event {
+unsafe impl FromEvent for Event {
     #[inline]
     fn is(_ev: &Event) -> bool {
         skip_assert_initialized!();

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -749,7 +749,7 @@ impl ParamSpec {
     }
 }
 
-pub trait ParamSpecType:
+pub unsafe trait ParamSpecType:
     StaticType + FromGlibPtrFull<*mut gobject_ffi::GParamSpec> + 'static
 {
 }
@@ -814,7 +814,7 @@ macro_rules! define_param_spec {
             }
         }
 
-        impl ParamSpecType for $rust_type {}
+        unsafe impl ParamSpecType for $rust_type {}
 
         #[doc(hidden)]
         impl FromGlibPtrFull<*mut gobject_ffi::GParamSpec> for $rust_type {


### PR DESCRIPTION
Implementing it requires ensuring that downcast() works.
Fixes https://github.com/gtk-rs/gtk-rs/issues/430