### PR TITLE
glib: Remove un-generatable type UriParamsIter

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -32,7 +32,6 @@ generate = [
     "GLib.UriFlags",
     "GLib.UriHideFlags",
     "GLib.UriParamsFlags",
-    "GLib.UriParamsIter",
 ]
 
 ignore = [


### PR DESCRIPTION
This is a boxed record that cannot be generated due to missing memory management functions.  That was previously silently permitted (and logged somewhere along the rest of the warnings) but is now proactively disallowed thanks to https://github.com/gtk-rs/gir/pull/1103.  Remove this type from the `generate` list since it has no effect anyway.
