### PR TITLE
gio: Rename TlsConnectionManualExt to ExtManual and export from prelude

### DIFF
--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -99,7 +99,6 @@ pub use crate::read_input_stream::ReadInputStream;
 mod write_output_stream;
 pub use crate::write_output_stream::WriteOutputStream;
 mod tls_connection;
-pub use crate::tls_connection::TlsConnectionManualExt;
 
 pub mod task;
 

--- a/gio/src/prelude.rs
+++ b/gio/src/prelude.rs
@@ -26,6 +26,7 @@ pub use crate::pollable_input_stream::PollableInputStreamExtManual;
 pub use crate::pollable_output_stream::PollableOutputStreamExtManual;
 pub use crate::settings::SettingsExtManual;
 pub use crate::socket::*;
+pub use crate::tls_connection::TlsConnectionExtManual;
 #[cfg(any(unix, feature = "dox"))]
 pub use crate::unix_input_stream::UnixInputStreamExtManual;
 #[cfg(any(unix, feature = "dox"))]

--- a/gio/src/tls_connection.rs
+++ b/gio/src/tls_connection.rs
@@ -9,7 +9,7 @@ use glib::IsA;
 #[cfg(any(feature = "v2_66", feature = "dox"))]
 use std::ptr;
 
-pub trait TlsConnectionManualExt {
+pub trait TlsConnectionExtManual {
     #[cfg(any(feature = "v2_66", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2_66")))]
     #[doc(alias = "g_tls_connection_get_channel_binding_data")]
@@ -19,7 +19,7 @@ pub trait TlsConnectionManualExt {
     ) -> Result<glib::ByteArray, glib::Error>;
 }
 
-impl<O: IsA<TlsConnection>> TlsConnectionManualExt for O {
+impl<O: IsA<TlsConnection>> TlsConnectionExtManual for O {
     #[cfg(any(feature = "v2_66", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2_66")))]
     fn channel_binding_data(


### PR DESCRIPTION
Noticed in [1] that this trait has ManualExt written the wrong way around, and is exported from the crate root instead of the prelude where all other traits are reexported.

[1]: https://github.com/gtk-rs/gir/pull/1111#issuecomment-826319140

CC @bilelmoussaoui
