### PR TITLE
GH workflows: Use actions-rs/toolchain `components` to install clippy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -138,7 +138,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: rustup component add rustfmt
+          components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,9 +20,9 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+          components: rustfmt
       - working-directory: gir
         run: cargo build --release
-      - run: rustup component add rustfmt
       - run: cargo install rustdoc-stripper
       - run: python3 ./generator.py --embed-docs --yes ./
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
This is a bit more elegant than manually invoking `rustup component add`.  Afaik it is synonymous to `rustup toolchain install <toolchain> --components <components>` which is why it has not been applied to the clippy step in CI.yml, as that would limit available nightlies when clippy is only used in the `stable` matrix runs.
