### PR TITLE
glib: manually bind g_unix_open_pipe

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -77,9 +77,6 @@ status = "generate"
     #string
     ignore = true
     [[object.function]]
-    name = "unix_open_pipe"
-    ignore = true
-    [[object.function]]
     pattern = "str.+"
     ignore = true
     [[object.function]]
@@ -181,6 +178,9 @@ status = "generate"
     [[object.function]]
     name = "spawn_command_line_async"
     cfg_condition = "unix"
+    [[object.function]]
+    name = "unix_open_pipe"
+    manual = true
     [[object.function]]
     name = "convert_with_fallback"
     #out param not in .gir


### PR DESCRIPTION
The API is not great, and I kept the plain `i32` flags argument since also the glib function takes the raw libc flag.

On the other hand this function is useful to bind because I did not find an equivalent function in `std` and I need the fd to pass to `SubprocessLauncher::take_fd`