### PR TITLE
Impl IntoGlib for Result...

### DIFF
--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -18,7 +18,7 @@
 //!     }
 //! ```
 //!
-//! Implementing [`OptionToGlib`] on a Rust type `T` allows specifying a sentinel to indicate
+//! Implementing [`OptionIntoGlib`] on a Rust type `T` allows specifying a sentinel to indicate
 //! a `None` value and auto-implementing [`FromGlib`] for `Option<T>`, which would not be
 //! possible in dependent crates due to the [orphan rule](https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type).
 //! In the example below, [`IntoGlib`] is auto-implemented for `Option<SpecialU32>`.
@@ -32,7 +32,7 @@
 //!         self.0 as libc::c_uint
 //!     }
 //! }
-//! impl OptionToGlib for SpecialU32 {
+//! impl OptionIntoGlib for SpecialU32 {
 //!     const GLIB_NONE: Self::GlibType = 0xFFFFFF;
 //! }
 //! ```
@@ -48,7 +48,7 @@
 //! #         self.0 as libc::c_uint
 //! #     }
 //! # }
-//! # impl OptionToGlib for SpecialU32 {
+//! # impl OptionIntoGlib for SpecialU32 {
 //! #     const GLIB_NONE: Self::GlibType = 0xFFFFFF;
 //! # }
 //! impl TryFromGlib<libc::c_uint> for SpecialU32 {
@@ -358,11 +358,11 @@ where
 }
 
 /// A Rust type `T` for which `Option<T>` translates to the same glib type as T.
-pub trait OptionToGlib: IntoGlib {
+pub trait OptionIntoGlib: IntoGlib {
     const GLIB_NONE: Self::GlibType;
 }
 
-impl<T: OptionToGlib> IntoGlib for Option<T> {
+impl<T: OptionIntoGlib> IntoGlib for Option<T> {
     type GlibType = T::GlibType;
 
     #[inline]
@@ -2458,7 +2458,7 @@ mod tests {
                 self.0 as libc::c_uint
             }
         }
-        impl OptionToGlib for SpecialU32 {
+        impl OptionIntoGlib for SpecialU32 {
             const GLIB_NONE: Self::GlibType = CLONG_NONE as libc::c_uint;
         }
 
@@ -2534,7 +2534,7 @@ mod tests {
                 self.0 as libc::c_long
             }
         }
-        impl OptionToGlib for SpecialU32 {
+        impl OptionIntoGlib for SpecialU32 {
             const GLIB_NONE: Self::GlibType = -1;
         }
 

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -340,6 +340,23 @@ impl IntoGlib for Ordering {
     }
 }
 
+impl<O, E, G> IntoGlib for Result<O, E>
+where
+    G: Copy,
+    O: IntoGlib<GlibType = G> + TryFromGlib<G, Error = E>,
+    E: IntoGlib<GlibType = G>,
+{
+    type GlibType = G;
+
+    #[inline]
+    fn into_glib(self) -> Self::GlibType {
+        match self {
+            Ok(ok) => ok.into_glib(),
+            Err(err) => err.into_glib(),
+        }
+    }
+}
+
 /// A Rust type `T` for which `Option<T>` translates to the same glib type as T.
 pub trait OptionToGlib: IntoGlib {
     const GLIB_NONE: Self::GlibType;


### PR DESCRIPTION
... when both the `Ok` and `Error` types implement `IntoGlib` to the same type and they are bound to a `Result` type due to a `TryFromGlib` impl. This helps the implementation of trampolines which return a type which `impl` `TryFromGlib`.

Also, rename `OptionToGlib` as `OptionIntoGlib` for consistency with `ToGlib` which was renamed as `IntoGlib`