### PR TITLE
glib: fix some nullables

### DIFF
--- a/gio/src/unix_mount_entry.rs
+++ b/gio/src/unix_mount_entry.rs
@@ -61,7 +61,7 @@ impl UnixMountEntry {
 
     #[doc(alias = "g_unix_mount_get_device_path")]
     #[doc(alias = "get_device_path")]
-    pub fn device_path(&self) -> Option<std::path::PathBuf> {
+    pub fn device_path(&self) -> std::path::PathBuf {
         unsafe {
             from_glib_none(ffi::g_unix_mount_get_device_path(mut_override(
                 self.to_glib_none().0,
@@ -71,7 +71,7 @@ impl UnixMountEntry {
 
     #[doc(alias = "g_unix_mount_get_fs_type")]
     #[doc(alias = "get_fs_type")]
-    pub fn fs_type(&self) -> Option<GString> {
+    pub fn fs_type(&self) -> GString {
         unsafe {
             from_glib_none(ffi::g_unix_mount_get_fs_type(mut_override(
                 self.to_glib_none().0,
@@ -80,7 +80,7 @@ impl UnixMountEntry {
     }
 
     #[doc(alias = "g_unix_mount_get_mount_path")]
-    pub fn unix_mount_get_mount_path(&self) -> Option<std::path::PathBuf> {
+    pub fn unix_mount_get_mount_path(&self) -> std::path::PathBuf {
         unsafe {
             from_glib_none(ffi::g_unix_mount_get_mount_path(mut_override(
                 self.to_glib_none().0,
@@ -122,7 +122,7 @@ impl UnixMountEntry {
     }
 
     #[doc(alias = "g_unix_mount_guess_icon")]
-    pub fn guess_icon(&self) -> Option<Icon> {
+    pub fn guess_icon(&self) -> Icon {
         unsafe {
             from_glib_full(ffi::g_unix_mount_guess_icon(mut_override(
                 self.to_glib_none().0,
@@ -131,7 +131,7 @@ impl UnixMountEntry {
     }
 
     #[doc(alias = "g_unix_mount_guess_name")]
-    pub fn guess_name(&self) -> Option<GString> {
+    pub fn guess_name(&self) -> GString {
         unsafe {
             from_glib_full(ffi::g_unix_mount_guess_name(mut_override(
                 self.to_glib_none().0,
@@ -149,7 +149,7 @@ impl UnixMountEntry {
     }
 
     #[doc(alias = "g_unix_mount_guess_symbolic_icon")]
-    pub fn guess_symbolic_icon(&self) -> Option<Icon> {
+    pub fn guess_symbolic_icon(&self) -> Icon {
         unsafe {
             from_glib_full(ffi::g_unix_mount_guess_symbolic_icon(mut_override(
                 self.to_glib_none().0,

--- a/glib/src/utils.rs
+++ b/glib/src/utils.rs
@@ -89,7 +89,7 @@ pub fn environ_getenv<K: AsRef<OsStr>>(envp: &[OsString], variable: K) -> Option
 
 #[doc(alias = "g_get_user_name")]
 #[doc(alias = "get_user_name")]
-pub fn user_name() -> Option<OsString> {
+pub fn user_name() -> OsString {
     #[cfg(not(all(windows, target_arch = "x86")))]
     use ffi::g_get_user_name;
     #[cfg(all(windows, target_arch = "x86"))]
@@ -100,7 +100,7 @@ pub fn user_name() -> Option<OsString> {
 
 #[doc(alias = "g_get_real_name")]
 #[doc(alias = "get_real_name")]
-pub fn real_name() -> Option<OsString> {
+pub fn real_name() -> OsString {
     #[cfg(not(all(windows, target_arch = "x86")))]
     use ffi::g_get_real_name;
     #[cfg(all(windows, target_arch = "x86"))]
@@ -173,7 +173,7 @@ pub fn find_program_in_path<P: AsRef<Path>>(program: P) -> Option<PathBuf> {
 
 #[doc(alias = "g_get_home_dir")]
 #[doc(alias = "get_home_dir")]
-pub fn home_dir() -> Option<std::path::PathBuf> {
+pub fn home_dir() -> std::path::PathBuf {
     #[cfg(not(all(windows, target_arch = "x86")))]
     use ffi::g_get_home_dir;
     #[cfg(all(windows, target_arch = "x86"))]


### PR DESCRIPTION
relevant c code

```c
      if (!e.user_name)
        e.user_name = g_strdup ("somebody");
      if (!e.real_name)
        e.real_name = g_strdup ("Unknown");
```

```c
  /* If we have been denied access to /etc/passwd (for example, by an
   * overly-zealous LSM), make up a junk value. The return value at this
   * point is explicitly documented as ‘undefined’. */
  if (home_dir == NULL)
    {
      g_warning ("Could not find home directory: $HOME is not set, and "
                 "user database could not be read.");
      home_dir = g_strdup ("/");
    }

```

and the rest according to docs and `auto/unix_mount_entry.rs`