### PR TITLE
glib-macros: do not export ::type_() for boxed types

### DIFF
--- a/glib-macros/src/gflags_attribute.rs
+++ b/glib-macros/src/gflags_attribute.rs
@@ -1,9 +1,9 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use heck::{CamelCase, KebabCase, SnakeCase};
+use heck::{CamelCase, KebabCase};
 use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
-use quote::{format_ident, quote, quote_spanned};
+use quote::{quote, quote_spanned};
 use syn::{
     punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Data, DeriveInput, Ident,
     LitStr, Variant, Visibility,
@@ -114,8 +114,6 @@ pub fn impl_gflags(input: &DeriveInput, gtype_name: &LitStr) -> TokenStream {
     };
 
     let bitflags = gen_bitflags(name, visibility, enum_variants, &crate_ident);
-
-    let get_type = format_ident!("{}_type", name.to_string().to_snake_case());
     let (gflags_values, nb_gflags_values) = gen_gflags_values(name, enum_variants);
 
     quote! {
@@ -168,34 +166,30 @@ pub fn impl_gflags(input: &DeriveInput, gtype_name: &LitStr) -> TokenStream {
 
         impl #crate_ident::StaticType for #name {
             fn static_type() -> #crate_ident::Type {
-                #get_type()
-            }
-        }
+                static ONCE: std::sync::Once = std::sync::Once::new();
+                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
 
-        fn #get_type() -> #crate_ident::Type {
-            static ONCE: std::sync::Once = std::sync::Once::new();
-            static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
+                ONCE.call_once(|| {
+                    static mut VALUES: [#crate_ident::gobject_ffi::GFlagsValue; #nb_gflags_values] = [
+                        #gflags_values
+                        #crate_ident::gobject_ffi::GFlagsValue {
+                            value: 0,
+                            value_name: std::ptr::null(),
+                            value_nick: std::ptr::null(),
+                        },
+                    ];
 
-            ONCE.call_once(|| {
-                static mut VALUES: [#crate_ident::gobject_ffi::GFlagsValue; #nb_gflags_values] = [
-                    #gflags_values
-                    #crate_ident::gobject_ffi::GFlagsValue {
-                        value: 0,
-                        value_name: std::ptr::null(),
-                        value_nick: std::ptr::null(),
-                    },
-                ];
+                    let name = std::ffi::CString::new(#gtype_name).expect("CString::new failed");
+                    unsafe {
+                        let type_ = #crate_ident::gobject_ffi::g_flags_register_static(name.as_ptr(), VALUES.as_ptr());
+                        TYPE = #crate_ident::translate::from_glib(type_);
+                    }
+                });
 
-                let name = std::ffi::CString::new(#gtype_name).expect("CString::new failed");
                 unsafe {
-                    let type_ = #crate_ident::gobject_ffi::g_flags_register_static(name.as_ptr(), VALUES.as_ptr());
-                    TYPE = #crate_ident::translate::from_glib(type_);
+                    assert!(TYPE.is_valid());
+                    TYPE
                 }
-            });
-
-            unsafe {
-                assert!(TYPE.is_valid());
-                TYPE
             }
         }
     }

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license, see the LICENSE file or <https://opensource.org/licenses/MIT>
 
 use glib::prelude::*;
-use glib::subclass::prelude::*;
 use glib::translate::{FromGlib, IntoGlib};
 use glib::{gflags, GBoxed, GEnum, GErrorDomain, GSharedBoxed};
 
@@ -29,10 +28,12 @@ fn derive_shared_arc() {
         foo: String,
     }
     #[derive(Debug, Eq, PartialEq, Clone, GSharedBoxed)]
-    #[gshared_boxed(type_name = "MySharedType")]
+    #[gshared_boxed(type_name = "MyShared")]
     struct MyShared(std::sync::Arc<MyInnerShared>);
 
-    assert_eq!(MyShared::type_().name(), "MySharedType");
+    let t = MyShared::static_type();
+    assert!(t.is_a(glib::Type::BOXED));
+    assert_eq!(t.name(), "MyShared");
 
     let p = MyShared(std::sync::Arc::new(MyInnerShared {
         foo: String::from("bar"),
@@ -56,10 +57,12 @@ fn derive_shared_arc_nullable() {
         foo: String,
     }
     #[derive(Clone, Debug, PartialEq, Eq, GSharedBoxed)]
-    #[gshared_boxed(type_name = "MyNullableSharedType", nullable)]
+    #[gshared_boxed(type_name = "MyNullableShared", nullable)]
     struct MyNullableShared(std::sync::Arc<MyInnerNullableShared>);
 
-    assert_eq!(MyNullableShared::type_().name(), "MyNullableSharedType");
+    let t = MyNullableShared::static_type();
+    assert!(t.is_a(glib::Type::BOXED));
+    assert_eq!(t.name(), "MyNullableShared");
 
     let p = MyNullableShared(std::sync::Arc::new(MyInnerNullableShared {
         foo: String::from("bar"),
@@ -137,7 +140,9 @@ fn derive_gboxed() {
     #[gboxed(type_name = "MyBoxed")]
     struct MyBoxed(String);
 
-    assert_eq!(MyBoxed::type_().name(), "MyBoxed");
+    let t = MyBoxed::static_type();
+    assert!(t.is_a(glib::Type::BOXED));
+    assert_eq!(t.name(), "MyBoxed");
 
     let b = MyBoxed(String::from("abc"));
     let v = b.to_value();
@@ -151,7 +156,9 @@ fn derive_gboxed_nullable() {
     #[gboxed(type_name = "MyNullableBoxed", nullable)]
     struct MyNullableBoxed(String);
 
-    assert_eq!(MyNullableBoxed::type_().name(), "MyNullableBoxed");
+    let t = MyNullableBoxed::static_type();
+    assert!(t.is_a(glib::Type::BOXED));
+    assert_eq!(t.name(), "MyNullableBoxed");
 
     let b = MyNullableBoxed(String::from("abc"));
     let v = b.to_value();

--- a/glib/src/subclass/boxed.rs
+++ b/glib/src/subclass/boxed.rs
@@ -3,6 +3,7 @@
 //! Module for registering boxed types for Rust types.
 
 use crate::translate::*;
+use crate::StaticType;
 
 /// Trait for defining boxed types.
 ///
@@ -12,19 +13,11 @@ use crate::translate::*;
 /// with the type system.
 ///
 /// [`register_boxed_type`]: fn.register_boxed_type.html
-pub trait BoxedType: Clone + Sized + 'static {
+pub trait BoxedType: StaticType + Clone + Sized + 'static {
     /// Boxed type name.
     ///
     /// This must be unique in the whole process.
     const NAME: &'static str;
-
-    /// Returns the type ID.
-    ///
-    /// This is usually defined via the [`GBoxed!`] derive macro.
-    ///
-    /// [`GBoxed!`]: ../../derive.GBoxed.html
-    #[doc(alias = "get_type")]
-    fn type_() -> crate::Type;
 }
 
 /// Register a boxed `glib::Type` ID for `T`.
@@ -67,12 +60,12 @@ pub fn register_boxed_type<T: BoxedType>() -> crate::Type {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     // We rename the current crate as glib, since the macros in glib-macros
     // generate the glib namespace through the crate_ident_new utility,
     // and that returns `glib` (and not `crate`) when called inside the glib crate
     use crate as glib;
     use crate::value::ToValue;
+    use crate::StaticType;
 
     #[derive(Clone, Debug, PartialEq, Eq, glib::GBoxed)]
     #[gboxed(type_name = "MyBoxed")]
@@ -80,12 +73,12 @@ mod test {
 
     #[test]
     fn test_register() {
-        assert!(MyBoxed::type_().is_valid());
+        assert!(MyBoxed::static_type().is_valid());
     }
 
     #[test]
     fn test_value() {
-        assert!(MyBoxed::type_().is_valid());
+        assert!(MyBoxed::static_type().is_valid());
 
         let b = MyBoxed(String::from("abc"));
         let v = b.to_value();

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -227,7 +227,7 @@
 //! struct MyBoxed(String);
 //!
 //! pub fn main() {
-//!     assert!(MyBoxed::type_().is_valid());
+//!     assert!(MyBoxed::static_type().is_valid());
 //!
 //!     let b = MyBoxed(String::from("abc"));
 //!     let v = b.to_value();

--- a/glib/src/subclass/shared.rs
+++ b/glib/src/subclass/shared.rs
@@ -3,6 +3,7 @@
 //! Module for registering shared types for Rust types.
 
 use crate::translate::*;
+use crate::StaticType;
 
 pub unsafe trait RefCounted: Clone + Sized + 'static {
     /// The inner type
@@ -67,7 +68,7 @@ where
 /// with the type system.
 ///
 /// [`register_shared_type`]: fn.register_shared_type.html
-pub trait SharedType: Clone + Sized + 'static {
+pub trait SharedType: StaticType + Clone + Sized + 'static {
     /// Shared type name.
     ///
     /// This must be unique in the whole process.
@@ -75,14 +76,6 @@ pub trait SharedType: Clone + Sized + 'static {
 
     /// The inner refcounted type
     type RefCountedType: RefCounted;
-
-    /// Returns the type ID.
-    ///
-    /// This is usually defined via the [`Shared!`] derive macro.
-    ///
-    /// [`Shared!`]: ../../derive.Shared.html
-    #[doc(alias = "get_type")]
-    fn type_() -> crate::Type;
 
     /// Converts the SharedType into its inner RefCountedType
     fn into_refcounted(self) -> Self::RefCountedType;
@@ -152,13 +145,13 @@ mod test {
 
     #[test]
     fn test_register() {
-        assert_ne!(crate::Type::INVALID, MySharedArc::type_());
-        assert_ne!(crate::Type::INVALID, MySharedRc::type_());
+        assert_ne!(crate::Type::INVALID, MySharedArc::static_type());
+        assert_ne!(crate::Type::INVALID, MySharedRc::static_type());
     }
 
     #[test]
     fn test_value_arc() {
-        assert_ne!(crate::Type::INVALID, MySharedArc::type_());
+        assert_ne!(crate::Type::INVALID, MySharedArc::static_type());
 
         let b = MySharedArc::from_refcounted(std::sync::Arc::new(MySharedInner {
             foo: String::from("abc"),
@@ -170,7 +163,7 @@ mod test {
 
     #[test]
     fn test_value_rc() {
-        assert_ne!(crate::Type::INVALID, MySharedRc::type_());
+        assert_ne!(crate::Type::INVALID, MySharedRc::static_type());
 
         let b = MySharedRc::from_refcounted(std::rc::Rc::new(MySharedInner {
             foo: String::from("abc"),
@@ -182,7 +175,7 @@ mod test {
 
     #[test]
     fn same_ffi_pointer_arc() {
-        assert_ne!(crate::Type::INVALID, MySharedArc::type_());
+        assert_ne!(crate::Type::INVALID, MySharedArc::static_type());
 
         let b = MySharedArc::from_refcounted(std::sync::Arc::new(MySharedInner {
             foo: String::from("abc"),
@@ -206,7 +199,7 @@ mod test {
 
     #[test]
     fn same_ffi_pointer_rc() {
-        assert_ne!(crate::Type::INVALID, MySharedRc::type_());
+        assert_ne!(crate::Type::INVALID, MySharedRc::static_type());
 
         let b = MySharedRc::from_refcounted(std::rc::Rc::new(MySharedInner {
             foo: String::from("abc"),


### PR DESCRIPTION
The proper way is to call ::static_type()